### PR TITLE
fix: Fix juju provider version

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -90,7 +90,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.11.0"
+      version = ">= 0.11.0"
     }
   }
 }

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -909,7 +909,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.11.0"
+      version = ">= 0.11.0"
     }
   }
 }

--- a/examples/terraform/getting_started/terraform.tf
+++ b/examples/terraform/getting_started/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.11.0"
+      version = ">= 0.11.0"
     }
   }
 }

--- a/examples/terraform/mastering/terraform.tf
+++ b/examples/terraform/mastering/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.11.0"
+      version = ">= 0.11.0"
     }
   }
 }


### PR DESCRIPTION
# Description

Allows using Juju Terraform provider versions >= 0.11.0

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
