### PR TITLE
fix: Allow using Juju Terraform provider version >= 0.11.0

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -90,7 +90,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.11.0"
+      version = ">= 0.11.0"
     }
   }
 }

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -909,7 +909,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.11.0"
+      version = ">= 0.11.0"
     }
   }
 }

--- a/examples/terraform/getting_started/terraform.tf
+++ b/examples/terraform/getting_started/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.11.0"
+      version = ">= 0.11.0"
     }
   }
 }

--- a/examples/terraform/mastering/terraform.tf
+++ b/examples/terraform/mastering/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.11.0"
+      version = ">= 0.11.0"
     }
   }
 }


### PR DESCRIPTION
# Description

Allows using Juju Terraform provider versions >= 0.11.0

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
