### PR TITLE
feat: Update mastering tutorial to use Infrastructure as Code

### DIFF
--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -38,7 +38,7 @@ Initialize LXD:
 lxd init --auto
 ```
 
-### Install Terraform 
+### Install Terraform
 
 Install Terraform:
 

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -66,8 +66,10 @@ terraform init
 terraform apply -auto-approve
 ```
 
+```note
 The current version of the Terraform module has some race conditions, if the deployment fail, a retry will
 usually fix the issue.
+```
 
 ### Checkpoint 1: Are the VM's ready ?
 

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -304,6 +304,7 @@ Add the Kubernetes clusters representing the user plane, control plane, and gNB 
 This is done by using the Kubernetes configuration file generated when setting up the clusters above.
 
 ```console
+cd /home/ubuntu
 export KUBECONFIG=control-plane-cluster.yaml
 juju add-k8s control-plane-cluster --controller sdcore
 export KUBECONFIG=user-plane-cluster.yaml

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -164,11 +164,11 @@ In this guide, the following network interfaces are available on the SD-Core `us
 
 | Interface Name | Purpose                                                                                                                                                           |
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| enp6s0         | internal Kubernetes management interface. This maps to the `management` subnet.                                                                                   |
-| enp7s0         | core interface. This maps to the `core` subnet.                                                                                                                   |
-| enp8s0         | access interface. This maps to the `access` subnet. Note that internet egress is required here and routing tables are already set to route gNB generated traffic. |
+| enp5s0         | internal Kubernetes management interface. This maps to the `management` subnet.                                                                                   |
+| enp6s0         | core interface. This maps to the `core` subnet.                                                                                                                   |
+| enp7s0         | access interface. This maps to the `access` subnet. Note that internet egress is required here and routing tables are already set to route gNB generated traffic. |
 
-Now we create the MACVLAN bridges for `enp7s0` and `enp8s0`.
+Now we create the MACVLAN bridges for `enp6s0` and `enp7s0`.
 These instructions are put into a file that is executed on reboot so the interfaces will come back:
 
 ```console
@@ -217,10 +217,10 @@ In this guide, the following network interfaces are available on the `gnbsim` VM
 
 | Interface Name | Purpose                                                                         |
 |----------------|---------------------------------------------------------------------------------|
-| enp6s0         | internal Kubernetes management interface. This maps to the `management` subnet. |
-| enp7s0         | ran interface. This maps to the `ran` subnet.                                   |
+| enp5s0         | internal Kubernetes management interface. This maps to the `management` subnet. |
+| enp6s0         | ran interface. This maps to the `ran` subnet.                                   |
 
-Now we create the MACVLAN bridges for `enp7s0`, and label them accordingly:
+Now we create the MACVLAN bridges for `enp6s0`, and label them accordingly:
 
 ```console
 cat << EOF | sudo tee /etc/rc.local

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -66,7 +66,7 @@ terraform init
 terraform apply -auto-approve
 ```
 
-```note
+```{note}
 The current version of the Terraform module has some race conditions, if the deployment fail, a retry will
 usually fix the issue.
 ```

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -362,7 +362,7 @@ terraform apply -auto-approve
 Monitor the status of the deployment:
 
 ```console
-watch -n 1 -c juju status --color --relations
+juju status --watch 1s --relations
 ```
 
 The deployment is ready when all the charms are in the `Active/Idle` state.
@@ -510,7 +510,7 @@ terraform apply -auto-approve
 Monitor the status of the deployment:
 
 ```console
-watch -n 1 -c juju status --color --relations
+juju status --watch 1s --relations
 ```
 
 The deployment is ready when the UPF application is in the `Active/Idle` state.
@@ -617,7 +617,7 @@ terraform apply -auto-approve
 Monitor the status of the deployment:
 
 ```console
-watch -n 1 -c juju status --color --relations
+juju status --watch 1s --relations
 ```
 
 The deployment is ready when the `gnbsim` application is in the `Active/Idle` state.
@@ -768,7 +768,7 @@ Monitor the status of the deployment:
 
 ```console
 juju switch cos-lite
-watch -n 1 -c juju status --color --relations
+juju status --watch 1s --relations
 ```
 
 The deployment is ready when all the charms are in the `Active/Idle` state.

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -123,6 +123,13 @@ In this step, we enable the MetalLB add on in MicroK8s, and give it a range of t
 sudo microk8s enable metallb:10.201.0.52-10.201.0.53
 ```
 
+Now update MicroK8s DNS to point to our DNS server:
+
+```console
+sudo microk8s disable dns
+sudo microk8s enable dns:10.201.0.1
+```
+
 Export the Kubernetes configuration and copy it to the `juju-controller` VM:
 
 ```console
@@ -151,6 +158,13 @@ sudo microk8s addons repo add community \
     --reference feat/strict-fix-multus
 sudo microk8s enable multus
 sudo usermod -a -G snap_microk8s $(whoami)
+```
+
+Now update MicroK8s DNS to point to our DNS server:
+
+```console
+sudo microk8s disable dns
+sudo microk8s enable dns:10.201.0.1
 ```
 
 Export the Kubernetes configuration and copy it to the `juju-controller` VM:
@@ -206,6 +220,13 @@ sudo microk8s enable multus
 sudo usermod -a -G snap_microk8s $(whoami)
 ```
 
+Now update MicroK8s DNS to point to our DNS server:
+
+```console
+sudo microk8s disable dns
+sudo microk8s enable dns:10.201.0.1
+```
+
 Export the Kubernetes configuration and copy it to the `juju-controller` VM:
 
 ```console
@@ -252,6 +273,19 @@ sudo microk8s enable hostpath-storage
 sudo microk8s enable metallb:10.201.0.50-10.201.0.51
 sudo usermod -a -G snap_microk8s $(whoami)
 newgrp snap_microk8s
+```
+
+Now update MicroK8s DNS to point to our DNS server:
+
+```console
+sudo microk8s disable dns
+sudo microk8s enable dns:10.201.0.1
+```
+
+```{note}
+The `microk8s enable` command confirms enabling the DNS before it actually happens.
+Before going forward, please make sure that the DNS is actually running.
+To do that run `microk8s.kubectl -n kube-system get pods` and make sure that the `coredns` pod is in `Running` status.
 ```
 
 Install Juju and bootstrap the controller to the local MicroK8s install as a LoadBalancer service.

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -175,9 +175,9 @@ These instructions are put into a file that is executed on reboot so the interfa
 cat << EOF | sudo tee /etc/rc.local
 #!/bin/bash
 
-sudo ip link add access link enp8s0 type macvlan mode bridge
+sudo ip link add access link enp7s0 type macvlan mode bridge
 sudo ip link set dev access up
-sudo ip link add core link enp7s0 type macvlan mode bridge
+sudo ip link add core link enp6s0 type macvlan mode bridge
 sudo ip link set dev core up
 EOF
 sudo chmod +x /etc/rc.local
@@ -226,7 +226,7 @@ Now we create the MACVLAN bridges for `enp7s0`, and label them accordingly:
 cat << EOF | sudo tee /etc/rc.local
 #!/bin/bash
 
-sudo ip link add ran link enp7s0 type macvlan mode bridge
+sudo ip link add ran link enp6s0 type macvlan mode bridge
 sudo ip link set dev ran up
 EOF
 sudo chmod +x /etc/rc.local

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -57,7 +57,7 @@ To complete this tutorial, you will need four virtual machines with access to th
 | Juju Controller + Kubernetes Cluster | 4    | 6g  | 40g  | `management`                   |
 | gNB Simulator Kubernetes Cluster     | 2    | 3g  | 20g  | `management`, `ran`            |
 
-The complete infrastructure can be created with terraform using the following commands:
+The complete infrastructure can be created with Terraform using the following commands:
 
 ```console
 git clone https://github.com/canonical/charmed-aether-sd-core.git
@@ -66,7 +66,7 @@ terraform init
 terraform apply -auto-approve
 ```
 
-The current version of the terraform module has some race conditions, if the deployment fail, a retry will
+The current version of the Terraform module has some race conditions, if the deployment fail, a retry will
 usually fix the issue.
 
 ### Checkpoint 1: Are the VM's ready ?

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -105,7 +105,7 @@ This section covers installation of necessary tools on the VMs which are going t
 Login to the `control-plane` VM:
 
 ```console
-lxc exec control-plane --user 1000 -- bash
+lxc exec control-plane --user 1000 -- bash -l
 ```
 
 Install MicroK8s:
@@ -144,7 +144,7 @@ Log out of the VM.
 Log in to the `user-plane` VM:
 
 ```console
-lxc exec user-plane --user 1000 -- bash
+lxc exec user-plane --user 1000 -- bash -l
 ```
 
 Install MicroK8s, configure MetalLB to expose 1 IP address for the UPF (`10.201.0.200`) and enable the Multus plugin:
@@ -205,7 +205,7 @@ Log out of the VM.
 Log in to the `gnbsim` VM:
 
 ```console
-lxc exec gnbsim --user 1000 -- bash
+lxc exec gnbsim --user 1000 -- bash -l
 ```
 
 Install MicroK8s and add the Multus plugin:
@@ -261,7 +261,7 @@ Log out of the VM.
 Log in to the `juju-controller` VM:
 
 ```console
-lxc exec juju-controller --user 1000 -- bash
+lxc exec juju-controller --user 1000 -- bash -l
 ```
 
 Begin by installing MicroK8s to hold the Juju controller.
@@ -427,6 +427,17 @@ control-plane    traefik       LoadBalancer  10.152.183.28   10.201.0.53   80:32
 
 Note both IPs - in this case `10.201.0.52` for the AMF and `10.201.0.53` for Traefik.
 We will need them shortly.
+
+```{note}
+If the IP for the AMF is not `10.201.0.52`, you will need to update the DNS entry. In the host,
+edit the `main.tf` file. Find the following line and set it to the right IP address, like so:
+
+`host-record=amf.mgmt,10.201.0.53`
+
+Then, run the following command on the host:
+
+`terraform apply -auto-approve`
+```
 
 Log out of the `control-plane` VM.
 
@@ -642,7 +653,7 @@ Update Juju Terraform provider:
 terraform init
 ```
 
-Deploy SD-Core User Plane:
+Deploy the gNB simulator:
 
 ```console
 terraform apply -auto-approve

--- a/terraform/gnbsim-network-config.yml
+++ b/terraform/gnbsim-network-config.yml
@@ -1,0 +1,15 @@
+network:
+  version: 2
+  ethernets:
+    mgmt:
+      match:
+        name: enp5s0
+      dhcp4: true
+    ran:
+      match:
+        name: enp6s0
+      dhcp4: true
+      routes:
+        - to: 10.202.0.0/24
+          via: 10.204.0.1
+          metric: 1

--- a/terraform/gnbsim-network-config.yml
+++ b/terraform/gnbsim-network-config.yml
@@ -9,6 +9,8 @@ network:
       match:
         name: enp6s0
       dhcp4: true
+      dhcp4-overrides:
+        use-routes: false
       routes:
         - to: 10.202.0.0/24
           via: 10.204.0.1

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,6 +25,10 @@ resource "lxd_network" "sdcore-mgmt" {
     "ipv6.address" = "none"
     "dns.mode" = "managed"
     "dns.domain" = "mgmt"
+    "raw.dnsmasq" = <<-EOF
+        host-record=amf.mgmt,10.201.0.52
+        host-record=upf.mgmt,10.201.0.200
+    EOF
   }
 }
 
@@ -71,7 +75,7 @@ resource "tls_private_key" "juju-key" {
 
 resource "lxd_instance" "control-plane" {
   name  = "control-plane"
-  image = "ubuntu:22.04"
+  image = "ubuntu:24.04"
   type = "virtual-machine"
 
   config = {
@@ -138,7 +142,7 @@ resource "lxd_instance_file" "control-plane-privkey" {
 
 resource "lxd_instance" "juju-controller" {
   name  = "juju-controller"
-  image = "ubuntu:22.04"
+  image = "ubuntu:24.04"
   type = "virtual-machine"
 
   config = {
@@ -205,7 +209,7 @@ resource "lxd_instance_file" "juju-controller-privkey" {
 
 resource "lxd_instance" "gnbsim" {
   name  = "gnbsim"
-  image = "ubuntu:22.04"
+  image = "ubuntu:24.04"
   type = "virtual-machine"
 
   config = {
@@ -284,7 +288,7 @@ resource "lxd_instance_file" "gnbsim-privkey" {
 
 resource "lxd_instance" "user-plane" {
   name  = "user-plane"
-  image = "ubuntu:22.04"
+  image = "ubuntu:24.04"
   type = "virtual-machine"
 
   config = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,374 @@
+terraform {
+  required_providers {
+    lxd = {
+      source = "terraform-lxd/lxd"
+      version = "2.1.0"
+    }
+  }
+}
+
+provider "lxd" {
+}
+
+resource "lxd_storage_pool" "sdcore-pool" {
+  name   = "sdcore-pool"
+  driver = "dir"
+}
+
+resource "lxd_network" "sdcore-mgmt" {
+  name = "sdcore-mgmt"
+  type = "bridge"
+
+  config = {
+    "ipv4.address" = "10.201.0.1/24"
+    "ipv4.nat"     = "true"
+    "ipv6.address" = "none"
+    "dns.mode" = "managed"
+    "dns.domain" = "mgmt"
+  }
+}
+
+resource "lxd_network" "sdcore-access" {
+  name = "sdcore-access"
+  type = "bridge"
+
+  config = {
+    "ipv4.address" = "10.202.0.1/24"
+    "ipv4.nat"     = "false"
+    "ipv6.address" = "none"
+    "dns.mode" = "none"
+  }
+}
+
+resource "lxd_network" "sdcore-core" {
+  name = "sdcore-core"
+  type = "bridge"
+
+  config = {
+    "ipv4.address" = "10.203.0.1/24"
+    "ipv4.nat"     = "true"
+    "ipv6.address" = "none"
+    "dns.mode" = "none"
+  }
+}
+
+resource "lxd_network" "sdcore-ran" {
+  name = "sdcore-ran"
+  type = "bridge"
+
+  config = {
+    "ipv4.address" = "10.204.0.1/24"
+    "ipv4.nat"     = "false"
+    "ipv6.address" = "none"
+    "dns.mode" = "none"
+  }
+}
+
+resource "tls_private_key" "juju-key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "lxd_instance" "control-plane" {
+  name  = "control-plane"
+  image = "ubuntu:22.04"
+  type = "virtual-machine"
+
+  config = {
+    "boot.autostart" = true
+  }
+
+  limits = {
+    cpu = 4
+    memory = "8GB"
+  }
+
+  device {
+    type = "disk"
+    name = "root"
+
+    properties = {
+      pool = "sdcore-pool"
+      path = "/"
+      size = "40GB"
+    }
+  }
+
+  device {
+    type = "nic"
+    name = "eth0"
+
+    properties = {
+      network = "sdcore-mgmt"
+      "ipv4.address" = "10.201.0.101"
+    }
+  }
+
+  depends_on = [
+    lxd_storage_pool.sdcore-pool,
+    lxd_network.sdcore-mgmt
+  ]
+}
+
+resource "lxd_instance_file" "control-plane-pubkey" {
+  instance = lxd_instance.control-plane.name
+  content = tls_private_key.juju-key.public_key_openssh
+  target_path = "/home/ubuntu/.ssh/authorized_keys"
+  uid = 1000
+  gid = 1000
+  mode = "0600"
+
+  depends_on = [
+    lxd_instance.control-plane
+  ]
+}
+
+resource "lxd_instance_file" "control-plane-privkey" {
+  instance = lxd_instance.control-plane.name
+  content = tls_private_key.juju-key.private_key_openssh
+  target_path = "/home/ubuntu/.ssh/id_rsa"
+  uid = 1000
+  gid = 1000
+  mode = "0600"
+
+  depends_on = [
+    lxd_instance.control-plane
+  ]
+}
+
+resource "lxd_instance" "juju-controller" {
+  name  = "juju-controller"
+  image = "ubuntu:22.04"
+  type = "virtual-machine"
+
+  config = {
+    "boot.autostart" = true
+  }
+
+  limits = {
+    cpu = 4
+    memory = "6GB"
+  }
+
+  device {
+    type = "disk"
+    name = "root"
+
+    properties = {
+      pool = "sdcore-pool"
+      path = "/"
+      size = "40GB"
+    }
+  }
+
+  device {
+    type = "nic"
+    name = "eth0"
+
+    properties = {
+      network = "sdcore-mgmt"
+      "ipv4.address" = "10.201.0.104"
+    }
+  }
+
+  depends_on = [
+    lxd_storage_pool.sdcore-pool,
+    lxd_network.sdcore-mgmt
+  ]
+}
+
+resource "lxd_instance_file" "juju-controller-pubkey" {
+  instance = lxd_instance.juju-controller.name
+  content = tls_private_key.juju-key.public_key_openssh
+  target_path = "/home/ubuntu/.ssh/authorized_keys"
+  uid = 1000
+  gid = 1000
+  mode = "0600"
+
+  depends_on = [
+    lxd_instance.juju-controller
+  ]
+}
+
+resource "lxd_instance_file" "juju-controller-privkey" {
+  instance = lxd_instance.juju-controller.name
+  content = tls_private_key.juju-key.private_key_openssh
+  target_path = "/home/ubuntu/.ssh/id_rsa"
+  uid = 1000
+  gid = 1000
+  mode = "0600"
+
+  depends_on = [
+    lxd_instance.juju-controller
+  ]
+}
+
+resource "lxd_instance" "gnbsim" {
+  name  = "gnbsim"
+  image = "ubuntu:22.04"
+  type = "virtual-machine"
+
+  config = {
+    "boot.autostart" = true
+    "cloud-init.network-config" = file("gnbsim-network-config.yml")
+  }
+
+  limits = {
+    cpu = 2
+    memory = "3GB"
+  }
+
+  device {
+    type = "disk"
+    name = "root"
+
+    properties = {
+      pool = "sdcore-pool"
+      path = "/"
+      size = "20GB"
+    }
+  }
+
+  device {
+    type = "nic"
+    name = "mgmt"
+
+    properties = {
+      network = "sdcore-mgmt"
+      "ipv4.address" = "10.201.0.103"
+    }
+  }
+
+  device {
+    type = "nic"
+    name = "ran"
+
+    properties = {
+      network = "sdcore-ran"
+      "ipv4.address" = "10.204.0.100"
+    }
+  }
+
+  depends_on = [
+    lxd_storage_pool.sdcore-pool,
+    lxd_network.sdcore-mgmt,
+    lxd_network.sdcore-ran
+  ]
+}
+
+resource "lxd_instance_file" "gnbsim-pubkey" {
+  instance = lxd_instance.gnbsim.name
+  content = tls_private_key.juju-key.public_key_openssh
+  target_path = "/home/ubuntu/.ssh/authorized_keys"
+  uid = 1000
+  gid = 1000
+  mode = "0600"
+
+  depends_on = [
+    lxd_instance.gnbsim
+  ]
+}
+
+resource "lxd_instance_file" "gnbsim-privkey" {
+  instance = lxd_instance.gnbsim.name
+  content = tls_private_key.juju-key.private_key_openssh
+  target_path = "/home/ubuntu/.ssh/id_rsa"
+  uid = 1000
+  gid = 1000
+  mode = "0600"
+
+  depends_on = [
+    lxd_instance.control-plane
+  ]
+}
+
+resource "lxd_instance" "user-plane" {
+  name  = "user-plane"
+  image = "ubuntu:22.04"
+  type = "virtual-machine"
+
+  config = {
+    "boot.autostart" = true
+    "cloud-init.network-config" = file("user-plane-network-config.yml")
+  }
+
+  limits = {
+    cpu = 2
+    memory = "8GB"
+  }
+
+  device {
+    type = "disk"
+    name = "root"
+
+    properties = {
+      pool = "sdcore-pool"
+      path = "/"
+      size = "20GB"
+    }
+  }
+
+  device {
+    type = "nic"
+    name = "eth0"
+
+    properties = {
+      network = "sdcore-mgmt"
+      "ipv4.address" = "10.201.0.102"
+    }
+  }
+
+  device {
+    type = "nic"
+    name = "eth1"
+
+    properties = {
+      network = "sdcore-core"
+      "ipv4.address" = "10.203.0.100"
+    }
+  }
+
+  device {
+    type = "nic"
+    name = "eth2"
+
+    properties = {
+      network = "sdcore-access"
+      "ipv4.address" = "10.202.0.100"
+      #"ipv4.routes" = "10.204.0.0/24"
+    }
+  }
+
+  depends_on = [
+    lxd_storage_pool.sdcore-pool,
+    lxd_network.sdcore-mgmt,
+    lxd_network.sdcore-core,
+    lxd_network.sdcore-access
+  ]
+}
+
+resource "lxd_instance_file" "user-plane-pubkey" {
+  instance = lxd_instance.user-plane.name
+  content = tls_private_key.juju-key.public_key_openssh
+  target_path = "/home/ubuntu/.ssh/authorized_keys"
+  uid = 1000
+  gid = 1000
+  mode = "0600"
+
+  depends_on = [
+    lxd_instance.user-plane
+  ]
+}
+
+resource "lxd_instance_file" "user-plane-privkey" {
+  instance = lxd_instance.user-plane.name
+  content = tls_private_key.juju-key.private_key_openssh
+  target_path = "/home/ubuntu/.ssh/id_rsa"
+  uid = 1000
+  gid = 1000
+  mode = "0600"
+
+  depends_on = [
+    lxd_instance.control-plane
+  ]
+}

--- a/terraform/user-plane-network-config.yml
+++ b/terraform/user-plane-network-config.yml
@@ -9,6 +9,8 @@ network:
       match:
         name: enp6s0
       dhcp4: true
+      dhcp4-overrides:
+        use-routes: false
       routes:
         - to: 10.202.0.0/24
           via: 10.204.0.1
@@ -17,6 +19,8 @@ network:
       match:
         name: enp7s0
       dhcp4: true
+      dhcp4-overrides:
+        use-routes: false
       routes:
         - to: 10.204.0.0/24
           via: 10.202.0.1

--- a/terraform/user-plane-network-config.yml
+++ b/terraform/user-plane-network-config.yml
@@ -1,0 +1,23 @@
+network:
+  version: 2
+  ethernets:
+    mgmt:
+      match:
+        name: enp5s0
+      dhcp4: true
+    core:
+      match:
+        name: enp6s0
+      dhcp4: true
+      routes:
+        - to: 10.202.0.0/24
+          via: 10.204.0.1
+          metric: 1
+    access:
+      match:
+        name: enp7s0
+      dhcp4: true
+      routes:
+        - to: 10.204.0.0/24
+          via: 10.202.0.1
+          metric: 1


### PR DESCRIPTION
# Description

This PR adds a Terraform module that deploys the required infrastructure to run the mastering tutorial. At the same time, it simplifies the setup by using LXD directly and using advanced features, like the automatic DNS on managed bridge networks.

The tutorial itself is simplified a lot and should be easier to run for users, with less chance for errors.

The Terraform module could also be reused for testing different scenarios.

**Known issues:**

- There is a race condition adding the SSH keys to the machines related to cloud-init execution. Retrying the `terraform apply` seems to work consistently.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
