### PR TITLE
fix: Use ethx naming for NIC devices

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -235,7 +235,7 @@ resource "lxd_instance" "gnbsim" {
 
   device {
     type = "nic"
-    name = "mgmt"
+    name = "eth0"
 
     properties = {
       network = "sdcore-mgmt"
@@ -245,7 +245,7 @@ resource "lxd_instance" "gnbsim" {
 
   device {
     type = "nic"
-    name = "ran"
+    name = "eth1"
 
     properties = {
       network = "sdcore-ran"


### PR DESCRIPTION
# Description
- Fixes https://github.com/canonical/charmed-aether-sd-core/issues/21
- Gnbsim VM networking is configured properly within this PR.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
