### PR TITLE
chore: Updates the name of the repository containing SD-Core root modules

### DIFF
--- a/docs/how-to/deploy_sdcore_cups.md
+++ b/docs/how-to/deploy_sdcore_cups.md
@@ -29,8 +29,8 @@ Get Charmed Aether SD-Core Terraform modules by cloning the [Charmed Aether SD-C
 Inside the `modules/sdcore-control-plane-k8s` directory, create a `control-plane.tfvars` file to set the name of Juju model for the deployment:
 
 ```console
-git clone https://github.com/canonical/terraform-juju-sdcore-k8s.git
-cd terraform-juju-sdcore-k8s/modules/sdcore-control-plane-k8s
+git clone https://github.com/canonical/terraform-juju-sdcore.git
+cd terraform-juju-sdcore/modules/sdcore-control-plane-k8s
 cat << EOF > control-plane.tfvars
 model_name = "control-plane"
 create_model = false
@@ -63,7 +63,7 @@ The AMF charm allows establishing the N2-plane connectivity through the `fiveg_n
 `````{tab-item} Option 1: Integration within the same Juju model
 
 It is assumed that the `fiveg-n2` requirer application is already deployed in the Juju model.
-To create a `fiveg_n2` integration between the AMF and another application within the same Juju model, add the following section to the `main.tf` file in the `terraform-juju-sdcore-k8s/modules/sdcore-control-plane-k8s` directory:
+To create a `fiveg_n2` integration between the AMF and another application within the same Juju model, add the following section to the `main.tf` file in the `terraform-juju-sdcore/modules/sdcore-control-plane-k8s` directory:
 
 ```console
 resource "juju_integration" "fiveg-n2" {
@@ -138,8 +138,8 @@ Get Charmed Aether SD-Core Terraform modules by cloning the [Charmed Aether SD-C
 Inside the `modules/sdcore-user-plane-k8s` directory, create a `user-plane.tfvars` file to set the name of Juju model for the deployment:
 
 ```console
-git clone https://github.com/canonical/terraform-juju-sdcore-k8s.git
-cd terraform-juju-sdcore-k8s/modules/sdcore-user-plane-k8s
+git clone https://github.com/canonical/terraform-juju-sdcore.git
+cd terraform-juju-sdcore/modules/sdcore-user-plane-k8s
 cat << EOF > user-plane.tfvars
 model_name = "user-plane"
 create_model = false
@@ -178,7 +178,7 @@ The UPF charm allows establishing the N4-plane connectivity through the `fiveg_n
 `````{tab-item} Option 1: Integration within the same Juju model
 
 It is assumed that the `fiveg_n4` requirer application is already deployed in the Juju model.
-To create a `fiveg_n4` integration between the UPF and another application within the same Juju model, add the following section to the `main.tf` file in the `terraform-juju-sdcore-k8s/modules/sdcore-user-plane-k8s` directory:
+To create a `fiveg_n4` integration between the UPF and another application within the same Juju model, add the following section to the `main.tf` file in the `terraform-juju-sdcore/modules/sdcore-user-plane-k8s` directory:
 
 ```console
 resource "juju_integration" "fiveg-n4" {
@@ -241,4 +241,4 @@ terraform apply -auto-approve
 
 ``````
 
-[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore-k8s
+[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore

--- a/docs/how-to/deploy_sdcore_standalone.md
+++ b/docs/how-to/deploy_sdcore_standalone.md
@@ -19,8 +19,8 @@ Get Charmed Aether SD-Core Terraform modules by cloning the [Charmed Aether SD-C
 Inside the `modules/sdcore-k8s` directory, create a `terraform.tfvars` file to set the name of Juju model for the deployment:
 
 ```console
-git clone https://github.com/canonical/terraform-juju-sdcore-k8s.git
-cd terraform-juju-sdcore-k8s/modules/sdcore-k8s
+git clone https://github.com/canonical/terraform-juju-sdcore.git
+cd terraform-juju-sdcore/modules/sdcore-k8s
 cat << EOF > terraform.tfvars
 model_name = "<YOUR_JUJU_MODEL_NAME>"
 EOF
@@ -62,4 +62,4 @@ To be effective, every configuration change needs to be applied using the follow
 terraform apply -var-file="terraform.tfvars" -auto-approve
 ```
 
-[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore-k8s
+[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore

--- a/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
+++ b/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
@@ -115,7 +115,7 @@ mkdir terraform
 cd terraform
 cat << EOF > main.tf
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-user-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s"
 
   model_name   = "user-plane"
   create_model = false

--- a/docs/how-to/integrate_sdcore_with_external_gnb.md
+++ b/docs/how-to/integrate_sdcore_with_external_gnb.md
@@ -57,4 +57,4 @@ resource "juju_integration" "nms-gnb01" {
 }
 ```
 
-[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore-k8s
+[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore

--- a/docs/how-to/integrate_sdcore_with_observability.md
+++ b/docs/how-to/integrate_sdcore_with_observability.md
@@ -101,4 +101,4 @@ Click on "Dashboards" -> "Browse" and select "5G Network Overview".
 :align: center
 ```
 
-[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore-k8s
+[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore

--- a/docs/reference/deployment_options.md
+++ b/docs/reference/deployment_options.md
@@ -32,6 +32,6 @@ Terraform module to deploy the 5G user plane in edge sites.
 
 `````
 
-[sdcore-k8s-terraform]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/main/modules/sdcore-k8s
-[sdcore-control-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/main/modules/sdcore-control-plane-k8s
-[sdcore-user-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/main/modules/sdcore-user-plane-k8s
+[sdcore-k8s-terraform]: https://github.com/canonical/terraform-juju-sdcore/tree/main/modules/sdcore-k8s
+[sdcore-control-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore/tree/main/modules/sdcore-control-plane-k8s
+[sdcore-user-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore/tree/main/modules/sdcore-user-plane-k8s

--- a/docs/tutorials/accelerated_networking.md
+++ b/docs/tutorials/accelerated_networking.md
@@ -291,7 +291,7 @@ Please replace the `access-interface-mac-address` and `core-interface-mac-addres
 cd terraform
 cat << EOF >> main.tf
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-user-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s"
 
   model_name   = "user-plane"
   create_model = false
@@ -358,5 +358,5 @@ unit-upf-0: 16:18:59 INFO unit.upf/0.juju-log Container bessd configured for DPD
 Go back to the Mastering tutorial and continue from step: [6. Deploy the gNB Simulator](mastering.md/#6-deploy-the-gnb-simulator).
 
 [SR-IOV Network Device Plugin]: https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin
-[sdcore-user-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/main/modules/sdcore-user-plane-k8s
+[sdcore-user-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore/tree/main/modules/sdcore-user-plane-k8s
 [LXD]: https://ubuntu.com/lxd

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -117,7 +117,7 @@ module "sdcore-router" {
 }
 
 module "sdcore" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
 
   model_name = juju_model.sdcore.name
   create_model = false

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -362,7 +362,7 @@ Create Terraform module:
 ```console
 cat << EOF > main.tf
 module "sdcore-control-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-control-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-control-plane-k8s"
 
   model_name   = "control-plane"
   create_model = false
@@ -516,7 +516,7 @@ Update the `main.tf` file:
 ```console
 cat << EOF >> main.tf
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-user-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s"
 
   model_name   = "user-plane"
   create_model = false
@@ -767,7 +767,7 @@ Add `cos-lite` Terraform module to the `main.tf` file used in the previous steps
 ```console
 cat << EOF >> main.tf
 module "cos-lite" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/external/cos-lite"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
 
   model_name               = "cos-lite"
   deploy_cos_configuration = true

--- a/examples/terraform/getting_started/main.tf
+++ b/examples/terraform/getting_started/main.tf
@@ -13,7 +13,7 @@ module "sdcore-router" {
 }
 
 module "sdcore" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
 
   model_name = juju_model.sdcore.name
   create_model = false

--- a/examples/terraform/mastering/main.tf
+++ b/examples/terraform/mastering/main.tf
@@ -1,5 +1,5 @@
 module "sdcore-control-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-control-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-control-plane-k8s"
 
   model_name = "control-plane"
   create_model = false
@@ -15,7 +15,7 @@ module "sdcore-control-plane" {
 }
 
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-user-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s"
 
   model_name   = "user-plane"
   create_model = false
@@ -48,7 +48,7 @@ module "gnbsim" {
 }
 
 module "cos-lite" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/external/cos-lite"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
 
   model_name               = "cos-lite"
   deploy_cos_configuration = true


### PR DESCRIPTION
# Description

This PR updates the name of the repository containing SD-Core root modules. We're loosing the `-k8s` suffix, because the repo will also hold the root module for the machine charm.

NOTE:
The repo hasn't been renamed yet, so please don't merge this PR.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
