### PR TITLE
chore: Updates the name of the repository containing SD-Core root modules

### DIFF
--- a/docs/how-to/deploy_sdcore_cups.md
+++ b/docs/how-to/deploy_sdcore_cups.md
@@ -29,9 +29,9 @@ Get Charmed Aether SD-Core Terraform modules by cloning the [Charmed Aether SD-C
 Inside the `modules/sdcore-control-plane-k8s` directory, create a `control-plane.tfvars` file to set the name of Juju model for the deployment:
 
 ```console
-git clone https://github.com/canonical/terraform-juju-sdcore-k8s.git
+git clone https://github.com/canonical/terraform-juju-sdcore.git
 git checkout v1.4
-cd terraform-juju-sdcore-k8s/modules/sdcore-control-plane-k8s
+cd terraform-juju-sdcore/modules/sdcore-control-plane-k8s
 cat << EOF > control-plane.tfvars
 model_name = "control-plane"
 create_model = false
@@ -64,7 +64,7 @@ The AMF charm allows establishing the N2-plane connectivity through the `fiveg_n
 `````{tab-item} Option 1: Integration within the same Juju model
 
 It is assumed that the `fiveg-n2` requirer application is already deployed in the Juju model.
-To create a `fiveg_n2` integration between the AMF and another application within the same Juju model, add the following section to the `main.tf` file in the `terraform-juju-sdcore-k8s/modules/sdcore-control-plane-k8s` directory:
+To create a `fiveg_n2` integration between the AMF and another application within the same Juju model, add the following section to the `main.tf` file in the `terraform-juju-sdcore/modules/sdcore-control-plane-k8s` directory:
 
 ```console
 resource "juju_integration" "fiveg-n2" {
@@ -139,9 +139,9 @@ Get Charmed Aether SD-Core Terraform modules by cloning the [Charmed Aether SD-C
 Inside the `modules/sdcore-user-plane-k8s` directory, create a `user-plane.tfvars` file to set the name of Juju model for the deployment:
 
 ```console
-git clone https://github.com/canonical/terraform-juju-sdcore-k8s.git
+git clone https://github.com/canonical/terraform-juju-sdcore.git
 git checkout v1.4
-cd terraform-juju-sdcore-k8s/modules/sdcore-user-plane-k8s
+cd terraform-juju-sdcore/modules/sdcore-user-plane-k8s
 cat << EOF > user-plane.tfvars
 model_name = "user-plane"
 create_model = false
@@ -180,7 +180,7 @@ The UPF charm allows establishing the N4-plane connectivity through the `fiveg_n
 `````{tab-item} Option 1: Integration within the same Juju model
 
 It is assumed that the `fiveg_n4` requirer application is already deployed in the Juju model.
-To create a `fiveg_n4` integration between the UPF and another application within the same Juju model, add the following section to the `main.tf` file in the `terraform-juju-sdcore-k8s/modules/sdcore-user-plane-k8s` directory:
+To create a `fiveg_n4` integration between the UPF and another application within the same Juju model, add the following section to the `main.tf` file in the `terraform-juju-sdcore/modules/sdcore-user-plane-k8s` directory:
 
 ```console
 resource "juju_integration" "fiveg-n4" {
@@ -243,4 +243,4 @@ terraform apply -auto-approve
 
 ``````
 
-[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/v1.4
+[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore/tree/v1.4

--- a/docs/how-to/deploy_sdcore_standalone.md
+++ b/docs/how-to/deploy_sdcore_standalone.md
@@ -19,9 +19,9 @@ Get Charmed Aether SD-Core Terraform modules by cloning the [Charmed Aether SD-C
 Inside the `modules/sdcore-k8s` directory, create a `terraform.tfvars` file to set the name of Juju model for the deployment:
 
 ```console
-git clone https://github.com/canonical/terraform-juju-sdcore-k8s.git
+git clone https://github.com/canonical/terraform-juju-sdcore.git
 git checkout v1.4
-cd terraform-juju-sdcore-k8s/modules/sdcore-k8s
+cd terraform-juju-sdcore/modules/sdcore-k8s
 cat << EOF > terraform.tfvars
 model_name = "<YOUR_JUJU_MODEL_NAME>"
 EOF
@@ -63,4 +63,4 @@ To be effective, every configuration change needs to be applied using the follow
 terraform apply -var-file="terraform.tfvars" -auto-approve
 ```
 
-[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/v1.4
+[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore/tree/v1.4

--- a/docs/how-to/integrate_sdcore_with_external_gnb.md
+++ b/docs/how-to/integrate_sdcore_with_external_gnb.md
@@ -57,4 +57,4 @@ resource "juju_integration" "nms-gnb01" {
 }
 ```
 
-[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore-k8s
+[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore

--- a/docs/how-to/integrate_sdcore_with_observability.md
+++ b/docs/how-to/integrate_sdcore_with_observability.md
@@ -101,4 +101,4 @@ Click on "Dashboards" -> "Browse" and select "5G Network Overview".
 :align: center
 ```
 
-[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/v1.4
+[Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore/tree/v1.4

--- a/docs/reference/deployment_options.md
+++ b/docs/reference/deployment_options.md
@@ -32,6 +32,6 @@ Terraform module to deploy the 5G user plane in edge sites.
 
 `````
 
-[sdcore-k8s-terraform]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/v1.4/modules/sdcore-k8s
-[sdcore-control-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/v1.4/modules/sdcore-control-plane-k8s
-[sdcore-user-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore-k8s/tree/v1.4/modules/sdcore-user-plane-k8s
+[sdcore-k8s-terraform]: https://github.com/canonical/terraform-juju-sdcore/tree/v1.4/modules/sdcore-k8s
+[sdcore-control-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore/tree/v1.4/modules/sdcore-control-plane-k8s
+[sdcore-user-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore/tree/v1.4/modules/sdcore-user-plane-k8s

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -115,7 +115,7 @@ module "sdcore-router" {
 }
 
 module "sdcore" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-k8s?ref=v1.4"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s?ref=v1.4"
 
   model_name = juju_model.sdcore.name
   create_model = false

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -921,7 +921,7 @@ Create Terraform module:
 ```console
 cat << EOF > main.tf
 module "sdcore-control-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-control-plane-k8s?ref=v1.4"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-control-plane-k8s?ref=v1.4"
 
   model_name   = "control-plane"
   create_model = false
@@ -1090,7 +1090,7 @@ Update the `main.tf` file:
 ```console
 cat << EOF >> main.tf
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-user-plane-k8s?ref=v1.4"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s?ref=v1.4"
 
   model_name   = "user-plane"
   create_model = false
@@ -1384,7 +1384,7 @@ Add `cos-lite` Terraform module to the `main.tf` file used in the previous steps
 ```console
 cat << EOF >> main.tf
 module "cos-lite" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/external/cos-lite?ref=v1.4"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite?ref=v1.4"
 
   model_name               = "cos-lite"
   deploy_cos_configuration = true

--- a/examples/terraform/getting_started/main.tf
+++ b/examples/terraform/getting_started/main.tf
@@ -14,7 +14,7 @@ module "sdcore-router" {
 }
 
 module "sdcore" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-k8s?ref=v1.4"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s?ref=v1.4"
 
   model_name = juju_model.sdcore.name
   create_model = false

--- a/examples/terraform/mastering/main.tf
+++ b/examples/terraform/mastering/main.tf
@@ -1,5 +1,5 @@
 module "sdcore-control-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-control-plane-k8s?ref=v1.4"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-control-plane-k8s?ref=v1.4"
 
   model_name = "control-plane"
   create_model = false
@@ -15,7 +15,7 @@ module "sdcore-control-plane" {
 }
 
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-user-plane-k8s?ref=v1.4"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s?ref=v1.4"
 
   model_name   = "user-plane"
   create_model = false
@@ -49,7 +49,7 @@ module "gnbsim" {
 }
 
 module "cos-lite" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/external/cos-lite?ref=v1.4"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite?ref=v1.4"
 
   model_name               = "cos-lite"
   deploy_cos_configuration = true


### PR DESCRIPTION
# Description

This PR updates the name of the repository containing SD-Core root modules. We're loosing the `-k8s` suffix, because the repo will also hold the root module for the machine charm.

NOTE:
The repo hasn't been renamed yet, so please don't merge this PR. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
