### PR TITLE
chore: Adds how-to for deploying UPF machine charm in DPDK mode

### DIFF
--- a/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
+++ b/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
@@ -1,23 +1,56 @@
 # Deploy SD-Core User Plane in DPDK mode
 
-This guide covers how to deploy the User Plane Function (UPF) in DPDK mode using the `sdcore-user-plane-k8s` Terraform Module.
+This guide covers how to deploy the User Plane Function (UPF) in DPDK mode using Terraform modules.
+Navigate between the tabs in each section of this guide to find the steps suitable for your setup (Kubernetes charm of Machine charm).
 
 ## Requirements
 
-- A Kubernetes cluster which meets below requirements:
-  - host CPU that supports AVX2, RDRAND and PDPE1GB instructions (Intel Haswell, AMD Excavator or equivalent)
+``````{tab-set}
+
+`````{tab-item} Kubernetes Charm
+
+- A Kubernetes cluster which meets or exceeds below requirements:
+  - CPU supporting AVX2 and RDRAND and PDPE1GB instructions (Intel Haswell, AMD Excavator or equivalent)
+  - Kernel with SCTP protocol and vfio-pci driver support
+  - 4 cores
   - SR-IOV interfaces for Access and Core networks
   - At least two 1G HugePages available
-  - `driverctl` is installed
+  - `driverctl` installed
   - LoadBalancer with 1 available address for the UPF
   - Multus CNI enabled
 - Juju >= 3.4/stable
 - A Juju controller bootstrapped onto the Kubernetes cluster
-- Terraform is installed
+- Terraform 
 
-## Change the driver of the network interfaces to `vfio-pci`
+`````
 
-As `root` user, load the `vfio-pci` driver on the Kubernetes host:
+`````{tab-item} Machine Charm
+
+- A UPF host which meets or exceeds below requirements:
+  - Ubuntu 24.04
+  - CPU supporting AVX2 and RDRAND and PDPE1GB instructions (Intel Haswell, AMD Excavator or equivalent)
+  - 4 cores
+  - At least two 1G HugePages available
+  - 3 network interfaces
+  - `driverctl` installed
+- Juju host
+  - Juju>=3.4
+  - Cloud of type `manual` created
+- Terraform
+
+`````
+
+``````
+
+## Configure UPF host
+
+``````{tab-set}
+
+`````{tab-item} Kubernetes Charm
+
+### Change the driver of the network interfaces to `vfio-pci`
+
+As `root` user on the UPF host, load the `vfio-pci` driver:
 
 ```shell
 echo "vfio-pci" > /etc/modules-load.d/vfio-pci.conf
@@ -48,7 +81,7 @@ sudo driverctl set-override 0000:00:06.0 vfio-pci
 sudo driverctl set-override 0000:00:07.0 vfio-pci
 ````
 
-## Configure Kubernetes for DPDK
+### Configure Kubernetes for DPDK
 
 Create ConfigMap with configuration for the [SR-IOV Network Device Plugin]:
 
@@ -94,7 +127,52 @@ sudo wget -O /opt/cni/bin/vfioveth https://raw.githubusercontent.com/opencord/om
 sudo chmod +x /opt/cni/bin/vfioveth
 ```
 
+`````
+
+`````{tab-item} Machine Charm
+
+### Change the driver of the network interfaces to `vfio-pci`
+
+As `root` user on the UPF host, load the `vfio-pci` driver:
+
+```shell
+echo "vfio-pci" > /etc/modules-load.d/vfio-pci.conf
+modprobe vfio-pci
+```
+
+```{note}
+Using `vfio-pci`, by default, needs IOMMU to be enabled. In the environments which do not support
+IOMMU, `vfio-pci` needs to be loaded with additional module parameter:
+`echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf`
+```
+
+Get PCI address of `access` and `core` interfaces:
+
+```shell
+$ sudo lshw -c network -businfo
+Bus info          Device           Class      Description
+=========================================================
+pci@0000:05:00.0  enp5s0           network    Virtio 1.0 network device
+pci@0000:06:00.0  enp6s0           network    Virtio 1.0 network device # access interface
+pci@0000:07:00.0  enp7s0           network    Virtio 1.0 network device # core interface
+```
+
+Bind `access` and `core` interfaces to the `vfio-pci` driver:
+
+```shell
+sudo driverctl set-override 0000:06:00.0 vfio-pci
+sudo driverctl set-override 0000:07:00.0 vfio-pci
+````
+
+`````
+
+``````
+
 ## Deploy SD-Core UPF Operator
+
+``````{tab-set}
+
+`````{tab-item} Kubernetes Charm
 
 Create a Juju model named `user-plane`:
 
@@ -106,8 +184,8 @@ Deploy `sdcore-user-plane-k8s` Terraform Module.
 Create an empty directory named `terraform` and create a `main.tf` file.
 
 ```{note}
-Please replace the `access-interface-mac-address` and `core-interface-mac-address` according your environment in the `upf_config`.
-If Kubernetes host is a virtual machine (not a Bare-metal host), set the `enable-hw-checksum` parameter in the `upf_config` to False.
+All the addresses presented below serve as an example. Make sure to replace them with the values matching your setup.
+If Kubernetes host is a virtual machine rather than a Bare-metal server, set the `enable-hw-checksum` parameter in the `upf_config` to False.
 ```
 
 ```shell
@@ -127,8 +205,8 @@ module "sdcore-user-plane" {
     access-ip             = "10.202.0.10/24"
     core-gateway-ip       = "10.203.0.1"
     core-ip               = "10.203.0.10/24"
-    access-interface-mac-address = "c2:c8:c7:e9:cc:18" # In this example, its the MAC address of access interface.
-    core-interface-mac-address = "e2:01:8e:95:cb:4d" # In this example, its the MAC address of core interface
+    access-interface-mac-address = "c2:c8:c7:e9:cc:18"
+    core-interface-mac-address = "e2:01:8e:95:cb:4d"
     enable-hw-checksum           = "false"
   }
 }
@@ -147,5 +225,75 @@ Deploy SD-Core User Plane:
 ```shell
 terraform apply -auto-approve
 ```
+
+`````
+
+`````{tab-item} Machine Charm
+
+Create a Juju model named `user-plane`:
+
+```shell
+juju add-model user-plane user-plane-cloud
+```
+
+Add UPF host to the model:
+
+```shell
+juju add-machine ssh:<USERNAME>@<UPF HOST NAME> --private-key <PATH TO THE SSH PRIVATE KEY>
+```
+
+Deploy `sdcore-user-plane` Terraform Module.
+Create an empty directory named `terraform` and create a `main.tf` file.
+
+```{note}
+All the addresses presented below serve as an example. Make sure to replace them with the values matching your setup.
+If the host is a virtual machine rather than a Bare-metal server, set the `enable-hw-checksum` parameter in the `upf_config` to False.
+```
+
+```shell
+mkdir terraform
+cd terraform
+cat << EOF > main.tf
+module "sdcore-user-plane" {
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane"
+
+  model_name     = "user-plane"
+  create_model   = false
+  machine_number = 0
+
+  upf_config = {
+    upf-mode                     = "dpdk"
+    access-interface-name        = "access"
+    access-ip                    = "10.202.0.10/24"
+    access-gateway-ip            = "10.202.0.1"
+    access-interface-mac-address = "c2:c8:c7:e9:cc:18"
+    access-interface-pci-address = "0000:06:00.0"
+    core-interface-name          = "core"
+    core-ip                      = "10.203.0.10/24"
+    core-gateway-ip              = "10.203.0.1"
+    core-interface-mac-address   = "e2:01:8e:95:cb:4d"
+    core-interface-pci-address   = "0000:07:00.0"
+    enable-hw-checksum           = "false"
+  }
+}
+
+EOF
+```
+
+Initialize the Juju Terraform provider:
+
+```shell
+terraform init
+```
+
+Deploy SD-Core User Plane:
+
+```shell
+terraform apply -auto-approve
+```
+
+`````
+
+``````
 
 [SR-IOV Network Device Plugin]: https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin

--- a/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
+++ b/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
@@ -1,13 +1,13 @@
 # Deploy SD-Core User Plane in DPDK mode
 
 This guide covers how to deploy the User Plane Function (UPF) in DPDK mode using Terraform modules.
-Navigate between the tabs in each section of this guide to find the steps suitable for your setup (Kubernetes charm of Machine charm).
-
-## Requirements
+Navigate between the tabs below to find the steps suitable for your setup (Kubernetes charm of Machine charm).
 
 ``````{tab-set}
 
 `````{tab-item} Kubernetes Charm
+
+## Requirements
 
 - A Kubernetes cluster which meets or exceeds below requirements:
   - CPU supporting AVX2 and RDRAND and PDPE1GB instructions (Intel Haswell, AMD Excavator or equivalent)
@@ -22,31 +22,7 @@ Navigate between the tabs in each section of this guide to find the steps suitab
 - A Juju controller bootstrapped onto the Kubernetes cluster
 - Terraform 
 
-`````
-
-`````{tab-item} Machine Charm
-
-- A UPF host which meets or exceeds below requirements:
-  - Ubuntu 24.04
-  - CPU supporting AVX2 and RDRAND and PDPE1GB instructions (Intel Haswell, AMD Excavator or equivalent)
-  - 4 cores
-  - At least two 1G HugePages available
-  - 3 network interfaces
-  - `driverctl` installed
-- Juju host
-  - Juju>=3.4
-  - Cloud of type `manual` created
-- Terraform
-
-`````
-
-``````
-
 ## Configure UPF host
-
-``````{tab-set}
-
-`````{tab-item} Kubernetes Charm
 
 ### Change the driver of the network interfaces to `vfio-pci`
 
@@ -127,52 +103,7 @@ sudo wget -O /opt/cni/bin/vfioveth https://raw.githubusercontent.com/opencord/om
 sudo chmod +x /opt/cni/bin/vfioveth
 ```
 
-`````
-
-`````{tab-item} Machine Charm
-
-### Change the driver of the network interfaces to `vfio-pci`
-
-As `root` user on the UPF host, load the `vfio-pci` driver:
-
-```shell
-echo "vfio-pci" > /etc/modules-load.d/vfio-pci.conf
-modprobe vfio-pci
-```
-
-```{note}
-Using `vfio-pci`, by default, needs IOMMU to be enabled. In the environments which do not support
-IOMMU, `vfio-pci` needs to be loaded with additional module parameter:
-`echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf`
-```
-
-Get PCI address of `access` and `core` interfaces:
-
-```shell
-$ sudo lshw -c network -businfo
-Bus info          Device           Class      Description
-=========================================================
-pci@0000:05:00.0  enp5s0           network    Virtio 1.0 network device
-pci@0000:06:00.0  enp6s0           network    Virtio 1.0 network device # access interface
-pci@0000:07:00.0  enp7s0           network    Virtio 1.0 network device # core interface
-```
-
-Bind `access` and `core` interfaces to the `vfio-pci` driver:
-
-```shell
-sudo driverctl set-override 0000:06:00.0 vfio-pci
-sudo driverctl set-override 0000:07:00.0 vfio-pci
-````
-
-`````
-
-``````
-
 ## Deploy SD-Core UPF Operator
-
-``````{tab-set}
-
-`````{tab-item} Kubernetes Charm
 
 Create a Juju model named `user-plane`:
 
@@ -229,6 +160,57 @@ terraform apply -auto-approve
 `````
 
 `````{tab-item} Machine Charm
+
+## Requirements
+
+- A UPF host which meets or exceeds below requirements:
+  - Ubuntu 24.04
+  - CPU supporting AVX2 and RDRAND and PDPE1GB instructions (Intel Haswell, AMD Excavator or equivalent)
+  - 4 cores
+  - At least two 1G HugePages available
+  - 3 network interfaces
+  - `driverctl` installed
+- Juju host
+  - Juju>=3.4
+  - Cloud of type `manual` created
+- Terraform
+
+## Configure UPF host
+
+### Change the driver of the network interfaces to `vfio-pci`
+
+As `root` user on the UPF host, load the `vfio-pci` driver:
+
+```shell
+echo "vfio-pci" > /etc/modules-load.d/vfio-pci.conf
+modprobe vfio-pci
+```
+
+```{note}
+Using `vfio-pci`, by default, needs IOMMU to be enabled. In the environments which do not support
+IOMMU, `vfio-pci` needs to be loaded with additional module parameter:
+`echo "options vfio enable_unsafe_noiommu_mode=1" > /etc/modprobe.d/vfio-noiommu.conf`
+```
+
+Get PCI address of `access` and `core` interfaces:
+
+```shell
+$ sudo lshw -c network -businfo
+Bus info          Device           Class      Description
+=========================================================
+pci@0000:05:00.0  enp5s0           network    Virtio 1.0 network device
+pci@0000:06:00.0  enp6s0           network    Virtio 1.0 network device # access interface
+pci@0000:07:00.0  enp7s0           network    Virtio 1.0 network device # core interface
+```
+
+Bind `access` and `core` interfaces to the `vfio-pci` driver:
+
+```shell
+sudo driverctl set-override 0000:06:00.0 vfio-pci
+sudo driverctl set-override 0000:07:00.0 vfio-pci
+```
+
+## Deploy SD-Core UPF Operator
 
 Create a Juju model named `user-plane`:
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -282,7 +282,7 @@ resource "lxd_instance_file" "gnbsim-privkey" {
   mode = "0600"
 
   depends_on = [
-    lxd_instance.control-plane
+    lxd_instance.gnbsim
   ]
 }
 
@@ -373,6 +373,6 @@ resource "lxd_instance_file" "user-plane-privkey" {
   mode = "0600"
 
   depends_on = [
-    lxd_instance.control-plane
+    lxd_instance.user-plane
   ]
 }


### PR DESCRIPTION
# Description

Adds how-to for deploying UPF machine charm in DPDK mode. 
To avoid creating new How-to, the existing DPDK doc will now have tabs describing configuration steps for both the K8s charm and the machine charm.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
