### PR TITLE
docs: upf k8s vs machine deployment options

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -89,6 +89,7 @@ MicroK
 Microk8s
 MNC
 Mongo
+MTU
 multipass
 Multus
 N3

--- a/docs/reference/deployment_options.md
+++ b/docs/reference/deployment_options.md
@@ -32,6 +32,35 @@ Terraform module to deploy the 5G user plane in edge sites.
 
 `````
 
+## User Plane Function
+
+The User Plane Function (UPF) is available in two different charms:
+
+`````{tab-set}
+    
+````{tab-item} Kubernetes
+
+The [UPF Kubernetes Charm](https://charmhub.io/sdcore-upf-k8s) can be deployed on a Kubernetes cluster. Network Configuration is done using Multus. Unless the charm is deployed in DPDK mode, the charm will not modify the host network configuration. To deploy the Kubernetes charm, follow this [guide](/how-to/deploy_sdcore_cups/).
+
+````
+
+````{tab-item} Machine
+
+The [UPF Machine charm](https://charmhub.io/sdcore-upf) can be deployed on a bare metal machine or a VM. The UPF machine charm will modify the host network configuration:
+- Create network interfaces (DPDK mode only)
+- Set interfaces IP addresses
+- Modify interfaces MTU
+- Set MAC addresses on interfaces (DPDK mode only)
+- Bring interfaces up
+- Create IP routes
+- Create IP tables rules
+
+To deploy the Machine charm, follow this [guide](/how-to/deploy_sdcore_upf_machine/).
+
+````
+
+`````
+
 [sdcore-k8s-terraform]: https://github.com/canonical/terraform-juju-sdcore/tree/main/modules/sdcore-k8s
 [sdcore-control-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore/tree/main/modules/sdcore-control-plane-k8s
 [sdcore-user-plane-k8s]: https://github.com/canonical/terraform-juju-sdcore/tree/main/modules/sdcore-user-plane-k8s

--- a/docs/reference/deployment_options.md
+++ b/docs/reference/deployment_options.md
@@ -40,7 +40,9 @@ The User Plane Function (UPF) is available in two different charms:
     
 ````{tab-item} Kubernetes
 
-The [UPF Kubernetes Charm](https://charmhub.io/sdcore-upf-k8s) can be deployed on a Kubernetes cluster. Network Configuration is done using Multus. Unless the charm is deployed in DPDK mode, the charm will not modify the host network configuration. To deploy the Kubernetes charm, follow this [guide](/how-to/deploy_sdcore_cups/).
+The [UPF Kubernetes Charm](https://charmhub.io/sdcore-upf-k8s) can be deployed on a Kubernetes cluster. The charm itself will not modify the host network configuration. Depending on the mode however users may need to modify the host network configuration prior to deploying the charm. To deploy the Kubernetes charm follow the guide matching the right mode:
+- [AF_PACKET](/how-to/deploy_sdcore_cups)
+- [DPDK](/how-to/deploy_sdcore_user_plane_in_dpdk_mode)
 
 ````
 


### PR DESCRIPTION
# Description

Clarify the differences between the K8s and machine deployment options for the UPF charm.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
