### PR TITLE
fix: use offer url instead of amf app name

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -119,7 +119,7 @@ module "sdcore-router" {
 module "sdcore" {
   source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
 
-  model_name = juju_model.sdcore.name
+  model_name   = juju_model.sdcore.name
   create_model = false
 
   traefik_config = {
@@ -145,8 +145,7 @@ resource "juju_integration" "gnbsim-amf" {
   }
 
   application {
-    name     = module.sdcore.amf_app_name
-    endpoint = module.sdcore.fiveg_n2_endpoint
+    offer_url = module.sdcore.amf_fiveg_n2_offer_url
   }
 }
 


### PR DESCRIPTION
# Description

We fix a bug in the tutorial that was caused by a change in the Terraform modules:
- https://github.com/canonical/terraform-juju-sdcore/pull/59/

## Logs

```
guillaume@thinkpad:~/terraform$ terraform apply --auto-approve
╷
│ Error: Unsupported attribute
│ 
│   on main.tf line 41, in resource "juju_integration" "gnbsim-amf":
│   41:     name     = module.sdcore.amf_app_name
│     ├────────────────
│     │ module.sdcore is a object
│ 
│ This object does not have an attribute named "amf_app_name".
╵
╷
│ Error: Unsupported attribute
│ 
│   on main.tf line 42, in resource "juju_integration" "gnbsim-amf":
│   42:     endpoint = module.sdcore.fiveg_n2_endpoint
│     ├────────────────
│     │ module.sdcore is a object
│ 
│ This object does not have an attribute named "fiveg_n2_endpoint".
╵
```
# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
