### PR TITLE
chore: use Juju 3.5 in the documentation

### DIFF
--- a/docs/how-to/deploy_sdcore_cups.md
+++ b/docs/how-to/deploy_sdcore_cups.md
@@ -4,7 +4,7 @@ This guide covers how to install a SD-Core 5G core network with Control Plane an
 
 ## Requirements
 
-- Juju >= 3.4
+- Juju >= 3.5
 - A Juju controller has been bootstrapped, and is externally reachable
 - A Control Plane Kubernetes cluster configured with
   - 1 available IP address for the Access and Mobility Management Function (AMF)

--- a/docs/how-to/deploy_sdcore_gnbsim.md
+++ b/docs/how-to/deploy_sdcore_gnbsim.md
@@ -4,7 +4,7 @@ This guide covers how to install and configure the SD-Core gNB Simulator.
 
 ## Requirements
 
-- Juju >= 3.4
+- Juju >= 3.5
 - A Juju controller has been bootstrapped
 - A Kubernetes cluster configured with Multus
 - 1 Juju cloud for the Kubernetes cluster has been added

--- a/docs/how-to/deploy_sdcore_standalone.md
+++ b/docs/how-to/deploy_sdcore_standalone.md
@@ -6,7 +6,7 @@ This guide covers how to install a standalone SD-Core 5G core network, suitable 
 
 You will need a Kubernetes cluster installed and configured with Multus.
 
-- Juju >= 3.4
+- Juju >= 3.5
 - Kubernetes >= 1.25
 - A `LoadBalancer` Service for Kubernetes with at least 3 addresses available
 - Multus

--- a/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
+++ b/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
@@ -18,7 +18,7 @@ Navigate between the tabs below to find the steps suitable for your setup (Kuber
   - `driverctl` installed
   - LoadBalancer with 1 available address for the UPF
   - Multus CNI enabled
-- Juju >= 3.4/stable
+- Juju >= 3.5/stable
 - A Juju controller bootstrapped onto the Kubernetes cluster
 - Terraform 
 
@@ -170,7 +170,7 @@ terraform apply -auto-approve
   - 3 network interfaces
   - `driverctl` installed
 - Juju host
-  - Juju>=3.4
+  - Juju>=3.5
   - Cloud of type `manual` created
 - Terraform
 

--- a/docs/how-to/troubleshoot_deployment_issues.md
+++ b/docs/how-to/troubleshoot_deployment_issues.md
@@ -91,5 +91,5 @@ After successful removal of the controller namespace, please follow [this guide]
 
 [Bug Report]: https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Fcanonical%2Fcharmed-aether-sd-core%2Fissues%2Fnew%3Fassignees%3D%26amp%3Blabels%3Dbug%26amp%3Bprojects%3D%26amp%3Btemplate%3Dbug_report.yml
 [Configure SD-Core K8s Deployment]: https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/latest/how-to/deploy_sdcore_standalone/#deploy
-[Remove Juju Controller]: https://juju.is/docs/juju/manage-controllers#destroy-a-controller
+[Remove Juju Controller]: https://juju.is/docs/juju/manage-controllers#remove-a-controller
 [Bootstrap Juju Controller]: https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/latest/tutorials/getting_started/#bootstrap-a-juju-controller

--- a/docs/how-to/troubleshoot_deployment_issues.md
+++ b/docs/how-to/troubleshoot_deployment_issues.md
@@ -65,7 +65,7 @@ $ juju controllers
 Use --refresh option with this command to see the latest information.
 
 Controller           Model      User   Access     Cloud/Region        Models  Nodes  HA  Version
-microk8s-localhost*  private5g  admin  superuser  microk8s/localhost       9      -   -  3.4.5  
+microk8s-localhost*  private5g  admin  superuser  microk8s/localhost       9      -   -  3.5.4  
 ```
 
 If your controller does not show up in the list, please follow [this guide][Bootstrap Juju Controller] to create a Juju controller.

--- a/docs/how-to/troubleshoot_user_plane_issues.md
+++ b/docs/how-to/troubleshoot_user_plane_issues.md
@@ -18,7 +18,7 @@ The UPF charm should be in `Active/Idle` status:
 
 ```shell
 Model      Controller                  Cloud/Region                Version  SLA          Timestamp
-private5g  microk8s-classic-localhost  microk8s-classic/localhost  3.4.6    unsupported  18:56:32Z
+private5g  microk8s-classic-localhost  microk8s-classic/localhost  3.5.4    unsupported  18:56:32Z
 
 App  Version  Status  Scale  Charm           Channel   Rev  Address         Exposed  Message
 upf  1.4.0    active      1  sdcore-upf-k8s  1.5/edge  622  10.152.183.236  no

--- a/docs/tutorials/accelerated_networking.md
+++ b/docs/tutorials/accelerated_networking.md
@@ -175,7 +175,7 @@ crw-rw-rw- 1 root root  10, 196 Aug 17 21:51 vfio
 Install the Microk8s and enable the `hostpath-storage`, `multus` and  `metallb` plugins.
 
 ```shell
-sudo snap install microk8s --channel=1.29/stable --classic
+sudo snap install microk8s --channel=1.31/stable --classic
 sudo microk8s enable hostpath-storage
 sudo microk8s addons repo add community https://github.com/canonical/microk8s-community-addons --reference feat/strict-fix-multus
 sudo microk8s enable multus

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -52,7 +52,7 @@ sudo microk8s enable metallb:10.0.0.2-10.0.0.4
 From your terminal, install Juju.
 
 ```console
-sudo snap install juju --channel=3.4/stable
+sudo snap install juju --channel=3.5/stable
 ```
 
 Bootstrap a Juju controller
@@ -164,7 +164,7 @@ Example:
 ```console
 ubuntu@host:~$ juju status
 Model      Controller                  Cloud/Region                Version  SLA          Timestamp
-sdcore  microk8s-localhost  microk8s-classic/localhost  3.4.5    unsupported  08:08:50Z
+sdcore  microk8s-localhost  microk8s-classic/localhost  3.5.4    unsupported  08:08:50Z
 
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
 amf                       1.4.4    active       1  sdcore-amf-k8s            1.5/edge       707  10.152.183.176  no       
@@ -325,7 +325,7 @@ Example:
 ```console
 ubuntu@host:~/terraform $ juju status
 Model  Controller          Cloud/Region        Version  SLA          Timestamp
-ran    microk8s-localhost  microk8s/localhost  3.4.3    unsupported  12:18:26+02:00
+ran    microk8s-localhost  microk8s/localhost  3.5.4    unsupported  12:18:26+02:00
 
 SAAS  Status  Store  URL
 amf   active  local  admin/sdcore.amf

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -22,7 +22,7 @@ To complete this tutorial, you will need a machine which meets the following req
 From your terminal, install MicroK8s:
 
 ```console
-sudo snap install microk8s --channel=1.27-strict/stable
+sudo snap install microk8s --channel=1.31-strict/stable
 ```
 
 Add your user to the `snap_microk8s` group:

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -113,7 +113,7 @@ lxc exec control-plane --user 1000 -- bash -l
 Install MicroK8s:
 
 ```console
-sudo snap install microk8s --channel=1.29-strict/stable
+sudo snap install microk8s --channel=1.31-strict/stable
 sudo microk8s enable hostpath-storage
 sudo usermod -a -G snap_microk8s $(whoami)
 ```
@@ -152,7 +152,7 @@ lxc exec user-plane --user 1000 -- bash -l
 Install MicroK8s, configure MetalLB to expose 1 IP address for the UPF (`10.201.0.200`) and enable the Multus plugin:
 
 ```console
-sudo snap install microk8s --channel=1.29-strict/stable
+sudo snap install microk8s --channel=1.31-strict/stable
 sudo microk8s enable hostpath-storage
 sudo microk8s enable metallb:10.201.0.200/32
 sudo microk8s addons repo add community \
@@ -213,7 +213,7 @@ lxc exec gnbsim --user 1000 -- bash -l
 Install MicroK8s and add the Multus plugin:
 
 ```console
-sudo snap install microk8s --channel=1.29-strict/stable
+sudo snap install microk8s --channel=1.31-strict/stable
 sudo microk8s enable hostpath-storage
 sudo microk8s addons repo add community \
     https://github.com/canonical/microk8s-community-addons \
@@ -270,7 +270,7 @@ Begin by installing MicroK8s to hold the Juju controller.
 Configure MetalLB to expose one IP address for the controller (`10.201.0.50`) and one for the Canonical Observability Stack (`10.201.0.51)`:
 
 ```console
-sudo snap install microk8s --channel=1.29-strict/stable
+sudo snap install microk8s --channel=1.31-strict/stable
 sudo microk8s enable hostpath-storage
 sudo microk8s enable metallb:10.201.0.50-10.201.0.51
 sudo usermod -a -G snap_microk8s $(whoami)

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -295,7 +295,7 @@ This will expose the Juju controller on the first allocated MetalLB address:
 
 ```console
 mkdir -p ~/.local/share/juju
-sudo snap install juju --channel=3.4/stable
+sudo snap install juju --channel=3.5/stable
 juju bootstrap microk8s --config controller-service-type=loadbalancer sdcore
 ```
 


### PR DESCRIPTION
# Description

Use Juju 3.5 and Microk8s 1.31.
Replace Remove Juju controller link as link check fails with the previous one.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
