### PR TITLE
docs: use https to access the NMS

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -349,7 +349,7 @@ juju switch sdcore
 juju run traefik/0 show-proxied-endpoints
 ```
 
-The output should be `http://sdcore-nms.10.0.0.4.nip.io/`. Navigate to this address in your
+The output should be `https://sdcore-nms.10.0.0.4.nip.io/`. Navigate to this address in your
 browser.
 
 In the Network Management System (NMS), create a network slice with the following attributes:

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -722,7 +722,7 @@ juju switch control-plane
 juju run traefik/0 show-proxied-endpoints
 ```
 
-The output should be `http://control-plane-nms.10.201.0.53.nip.io/`.
+The output should be `https://control-plane-nms.10.201.0.53.nip.io/`.
 Navigate to this address in your browser.
 
 In the Network Management System (NMS), create a network slice with the following attributes:


### PR DESCRIPTION
# Description

This PR updates the tutorials to specify that the external address returned by traefik is `https` instead of `http`, after the TLS integration was added to the NMS.

# Checklist:

- [x] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
