### PR TITLE
docs: add login step to tutorials

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -53,6 +53,7 @@ gNBs
 gnbsim
 Gnbsim
 gNodeB
+gNodeBs
 Grafana
 GTP
 hardcoded

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,4 +7,5 @@ charms
 deployment_options
 networking
 public_clouds
+user_management
 ```

--- a/docs/reference/user_management.md
+++ b/docs/reference/user_management.md
@@ -1,9 +1,7 @@
 # User Management in the NMS
 
-Upon initialization, the NMS charm creates a first admin user in NMS and securely stores its credentials in a Juju secret with the label `NMS_LOGIN`. These credentials are used by the NMS charm to manage inventory resources like gNodeB's and UPFs. The same credentials can be used by the administrator to log in to the NMS and perform operations.
+Upon initialization, the NMS charm creates an admin user in NMS and securely stores its credentials in a Juju secret with the label `NMS_LOGIN`. These credentials are used by the NMS charm to manage inventory resources like gNodeB's and UPFs. The same credentials can be used by the administrator to log in to the NMS and perform operations.
 
-The NMS allows the admin user to manage all users, including creating, changing passwords, and deleting accounts. Other users can manage all resources except user accounts.
+In the NMS, there is a single admin account with full access to manage all resources, including user accounts. Admin accounts cannot be deleted or have their passwords changed.
 
-```{note}
-It is not possible to delete the admin user or change their password.
-```
+Other user accounts are created with the `user` role, which allows them to manage all resources except user accounts.

--- a/docs/reference/user_management.md
+++ b/docs/reference/user_management.md
@@ -1,4 +1,4 @@
-# User Management
+# User Management in the NMS
 
 The Charmed Aether SD-Core automatically creates an admin user whose username and password are securely stored in Juju secrets. These credentials are used to log in to the Network Management System (NMS).
 

--- a/docs/reference/user_management.md
+++ b/docs/reference/user_management.md
@@ -1,7 +1,7 @@
 # User Management in the NMS
 
-Upon initialization, the NMS charm creates an admin user in NMS and securely stores its credentials in a Juju secret with the label `NMS_LOGIN`. These credentials are used by the NMS charm to manage inventory resources like gNodeBs and UPFs. The same credentials can be used by the administrator to log in to the NMS and perform operations.
+Upon initialization, the NMS charm creates an admin user in NMS and securely stores its credentials in a Juju secret with the label `NMS_LOGIN`. These credentials are used by the NMS charm to manage inventory resources, such as gNodeBs and UPFs. Additionally, the administrator can use the same credentials to log in to the NMS and perform operations.
 
-In the NMS, there is a single admin account with full access to manage all resources, including user accounts. Admin accounts cannot be deleted or have their passwords changed.
+In the NMS, there is a single admin account with full access to manage all resources, including user accounts. This account cannot be deleted or have its password changed.
 
 Other user accounts are created with the `user` role, which allows them to manage all resources except user accounts.

--- a/docs/reference/user_management.md
+++ b/docs/reference/user_management.md
@@ -1,6 +1,6 @@
 # User Management in the NMS
 
-Upon initialization, the NMS charm creates an admin user in NMS and securely stores its credentials in a Juju secret with the label `NMS_LOGIN`. These credentials are used by the NMS charm to manage inventory resources like gNodeB's and UPFs. The same credentials can be used by the administrator to log in to the NMS and perform operations.
+Upon initialization, the NMS charm creates an admin user in NMS and securely stores its credentials in a Juju secret with the label `NMS_LOGIN`. These credentials are used by the NMS charm to manage inventory resources like gNodeBs and UPFs. The same credentials can be used by the administrator to log in to the NMS and perform operations.
 
 In the NMS, there is a single admin account with full access to manage all resources, including user accounts. Admin accounts cannot be deleted or have their passwords changed.
 

--- a/docs/reference/user_management.md
+++ b/docs/reference/user_management.md
@@ -1,0 +1,9 @@
+# User Management
+
+The Charmed Aether SD-Core automatically creates an admin user whose username and password are securely stored in Juju secrets. These credentials are used to log in to the Network Management System (NMS).
+
+The NMS allows the admin user to manage all users, including creating, changing passwords, and deleting accounts. Other users can manage all resources except user accounts.
+
+```{caution}
+Avoid changing the admin user's password directly in the NMS. This password must also be updated in the corresponding Juju secret to prevent inconsistencies and maintain system accessibility.
+```

--- a/docs/reference/user_management.md
+++ b/docs/reference/user_management.md
@@ -1,6 +1,6 @@
 # User Management in the NMS
 
-The Charmed Aether SD-Core automatically creates an admin user whose username and password are securely stored in Juju secrets. These credentials are used to log in to the Network Management System (NMS).
+Upon initialization, the NMS charm creates a first admin user in NMS and securely stores its credentials in a Juju secret with the label `NMS_LOGIN`. These credentials are used by the NMS charm to manage inventory resources like gNodeB's and UPFs. The same credentials can be used by the administrator to log in to the NMS and perform operations.
 
 The NMS allows the admin user to manage all users, including creating, changing passwords, and deleting accounts. Other users can manage all resources except user accounts.
 

--- a/docs/reference/user_management.md
+++ b/docs/reference/user_management.md
@@ -4,6 +4,6 @@ The Charmed Aether SD-Core automatically creates an admin user whose username an
 
 The NMS allows the admin user to manage all users, including creating, changing passwords, and deleting accounts. Other users can manage all resources except user accounts.
 
-```{caution}
-Avoid changing the admin user's password directly in the NMS. This password must also be updated in the corresponding Juju secret to prevent inconsistencies and maintain system accessibility.
+```{note}
+It is not possible to delete the admin user or change their password.
 ```

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -342,15 +342,34 @@ gnbsim  gnbsim       sdcore-gnbsim-k8s  557  1/1        fiveg_gnb_identity  five
 
 ## 7. Configure the 5G core network through the Network Management System
 
-Retrieve the NMS address:
+Retrieve the NMS credentials (`username` and `password`):
 
 ```console
 juju switch sdcore
+juju show-secret $(juju secrets | awk '/nms[^\/]/ {print $1}') --reveal
+```
+The output looks like this:
+```
+csurgu7mp25c761k2oe0:
+  revision: 1
+  owner: nms
+  label: NMS_LOGIN
+  created: 2024-11-20T10:22:49Z
+  updated: 2024-11-20T10:22:49Z
+  content:
+    password: ',u7=VEE3XK%t'
+    token: ""
+    username: charm-admin-SOOO
+```
+
+Retrieve the NMS address:
+
+```console
 juju run traefik/0 show-proxied-endpoints
 ```
 
 The output should be `https://sdcore-nms.10.0.0.4.nip.io/`. Navigate to this address in your
-browser.
+browser and use the `username` and `password` to login.
 
 In the Network Management System (NMS), create a network slice with the following attributes:
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -346,7 +346,7 @@ Retrieve the NMS credentials (`username` and `password`):
 
 ```console
 juju switch sdcore
-juju show-secret $(juju secrets | awk '/nms[^\/]/ {print $1}') --reveal
+juju show-secret NMS_LOGIN --reveal
 ```
 The output looks like this:
 ```

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -715,15 +715,34 @@ Apply the changes:
 terraform apply -auto-approve
 ```
 
-Retrieve the NMS address:
+Retrieve the NMS credentials (`username` and `password`):
 
 ```console
 juju switch control-plane
+juju show-secret $(juju secrets | awk '/nms[^\/]/ {print $1}') --reveal
+```
+The output looks like this:
+```
+csurgu7mp25c761k2oe0:
+  revision: 1
+  owner: nms
+  label: NMS_LOGIN
+  created: 2024-11-20T10:22:49Z
+  updated: 2024-11-20T10:22:49Z
+  content:
+    password: ',u7=VEE3XK%t'
+    token: ""
+    username: charm-admin-SOOO
+```
+
+Retrieve the NMS address:
+
+```console
 juju run traefik/0 show-proxied-endpoints
 ```
 
 The output should be `https://control-plane-nms.10.201.0.53.nip.io/`.
-Navigate to this address in your browser.
+Navigate to this address in your browser and use the `username` and `password` to login.
 
 In the Network Management System (NMS), create a network slice with the following attributes:
 

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -719,7 +719,7 @@ Retrieve the NMS credentials (`username` and `password`):
 
 ```console
 juju switch control-plane
-juju show-secret $(juju secrets | awk '/nms[^\/]/ {print $1}') --reveal
+juju show-secret NMS_LOGIN --reveal
 ```
 The output looks like this:
 ```


### PR DESCRIPTION
# Description

Now we have authentication for the NMS. This PR add the steps to login to the tutorials  and a reference for user management.
To retrieve the username and password we need to reveal the juju secret associated to the NMS application.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
