### PR TITLE
chore: move to channel 6/stable in mongodb

### DIFF
--- a/docs/how-to/backup_sdcore.md
+++ b/docs/how-to/backup_sdcore.md
@@ -6,7 +6,7 @@ highlights the steps required by referencing that charm's documentation.
 ## Integrate Mongo with S3
 
 `mongodb-k8s` saves backup to S3 compatible storage. The first step is to
-[configure S3 storage](https://charmhub.io/mongodb-k8s/docs/h-configure-s3?channel=6/beta).
+[configure S3 storage](https://charmhub.io/mongodb-k8s/docs/h-configure-s3?channel=6/stable).
 
 ## Save the cluster password
 
@@ -22,4 +22,4 @@ Save the password in a safe place.
 ## Create and list backups
 
 `mongodb-k8s` is now ready to
-[create and list backups](https://charmhub.io/mongodb-k8s/docs/h-create-backup?channel=6/beta).
+[create and list backups](https://charmhub.io/mongodb-k8s/docs/h-create-backup?channel=6/stable).

--- a/docs/how-to/restore_sdcore.md
+++ b/docs/how-to/restore_sdcore.md
@@ -22,12 +22,12 @@ juju add-model core
 ## Deploy `mongodb-k8s`
 
 ```bash
-juju deploy mongodb-k8s --channel 6/beta
+juju deploy mongodb-k8s --channel 6/stable
 ```
 
 ## Follow the restore procedure
 
-Use this [procedure](https://charmhub.io/mongodb-k8s/docs/h-restore-backup?channel=6/beta)
+Use this [procedure](https://charmhub.io/mongodb-k8s/docs/h-restore-backup?channel=6/stable)
 to restore the backup.
 
 ## Redeploy the bundle

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -170,7 +170,7 @@ App                       Version  Status   Scale  Charm                     Cha
 amf                       1.4.4    active       1  sdcore-amf-k8s            1.5/edge       707  10.152.183.176  no       
 ausf                      1.4.2    active       1  sdcore-ausf-k8s           1.5/edge       520  10.152.183.65   no       
 grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         latest/stable   45  10.152.183.221  no       installing agent
-mongodb                            active       1  mongodb-k8s               6/beta          38  10.152.183.92   no       Primary
+mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.92   no       Primary
 nms                       1.0.0    active       1  sdcore-nms-k8s            1.5/edge       580  10.152.183.141  no       
 nrf                       1.4.1    active       1  sdcore-nrf-k8s            1.5/edge       580  10.152.183.130  no       
 nssf                      1.4.1    active       1  sdcore-nssf-k8s           1.5/edge       462  10.152.183.62   no       


### PR DESCRIPTION
# Description

This PR sets the the `6/stable` channel for mongodb charm instead of `6/beta`

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
