### PR TITLE
chore: Update documentation for 1.5 release

### DIFF
--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -6,17 +6,6 @@ Each charm in Charmed Aether SD-Core is distributed by Canonical as a ROCK conta
 
 Each image is chiseled to contain only the bare minimum to run the application. This means that the images are small, and contain only the necessary dependencies to run the application. This reduces the attack surface of the application and makes it easier to maintain.
 
-Take the SMF image as an example:
-
-```console
-ubuntu@server:~$ docker images
-REPOSITORY                          TAG             IMAGE ID       CREATED        SIZE
-ghcr.io/canonical/sdcore-smf        1.4             e15917b9cce9   18 hours ago   51MB  # Charmed Aether SD-Core image
-omecproject/5gc-smf                 master-latest   d4b790e2c492   4 months ago   104MB  # Upstream image
-```
-
-The Charmed Aether SD-Core image of the SMF is less than half the size of the upstream image. This level of size reduction is typical for all Charmed Aether SD-Core images with the total size of the SD-Core workloads being around 1GB, contrasting with 2GB in the upstream project.
-
 Each Charmed Aether SD-Core ROCK is scanned for vulnerabilities and built on a weekly schedule. This means that the images are always up-to-date with the latest security patches and bug fixes.
 
 ## TLS everywhere

--- a/docs/how-to/deploy_sdcore_gnbsim.md
+++ b/docs/how-to/deploy_sdcore_gnbsim.md
@@ -20,7 +20,7 @@ juju add-model gnbsim gnbsim-cloud
 Deploy the `sdcore-gnbsim-k8s` operator charm.
 
 ```console
-juju deploy sdcore-gnbsim-k8s gnbsim --trust --channel=1.5/edge \
+juju deploy sdcore-gnbsim-k8s gnbsim --trust --channel=1.5/stable \
   --config gnb-interface=ran \
   --config gnb-ip-address=10.204.0.10/24 \
   --config icmp-packet-destination=8.8.8.8 \

--- a/docs/how-to/integrate_sdcore_with_external_gnb.md
+++ b/docs/how-to/integrate_sdcore_with_external_gnb.md
@@ -31,7 +31,7 @@ module "gnb01" {
   app_name   = "gnb01"
   source     = "git::https://github.com/canonical/sdcore-gnb-integrator//terraform?ref=v1.5"
   model_name = "gnb-integration"
-  channel    = "1.5/edge"
+  channel    = "1.5/stable"
   config     = {
     tac: B01F
   }

--- a/docs/how-to/integrate_sdcore_with_external_gnb.md
+++ b/docs/how-to/integrate_sdcore_with_external_gnb.md
@@ -29,7 +29,7 @@ Either create a new `.tf` file, or add the following content to you existing `ma
 ```console
 module "gnb01" {
   app_name   = "gnb01"
-  source     = "git::https://github.com/canonical/sdcore-gnb-integrator//terraform"
+  source     = "git::https://github.com/canonical/sdcore-gnb-integrator//terraform?ref=v1.5"
   model_name = "gnb-integration"
   channel    = "1.5/edge"
   config     = {

--- a/docs/how-to/troubleshoot_user_plane_issues.md
+++ b/docs/how-to/troubleshoot_user_plane_issues.md
@@ -20,8 +20,8 @@ The UPF charm should be in `Active/Idle` status:
 Model      Controller                  Cloud/Region                Version  SLA          Timestamp
 private5g  microk8s-classic-localhost  microk8s-classic/localhost  3.5.4    unsupported  18:56:32Z
 
-App  Version  Status  Scale  Charm           Channel   Rev  Address         Exposed  Message
-upf  1.4.0    active      1  sdcore-upf-k8s  1.5/edge  622  10.152.183.236  no
+App  Version  Status  Scale  Charm           Channel     Rev  Address         Exposed  Message
+upf  1.5.0    active      1  sdcore-upf-k8s  1.5/stable  622  10.152.183.236  no
 
 Unit    Workload  Agent  Address       Ports  Message
 upf/0*  active    idle   10.1.145.115

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -109,14 +109,14 @@ resource "juju_model" "sdcore" {
 }
 
 module "sdcore-router" {
-  source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform"
+  source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform?ref=v1.5"
 
   model      = juju_model.sdcore.name
   depends_on = [juju_model.sdcore]
 }
 
 module "sdcore" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s?ref=v1.5"
 
   model        = juju_model.sdcore.name
   depends_on = [module.sdcore-router]
@@ -163,42 +163,46 @@ Example:
 
 ```console
 ubuntu@host:~$ juju status
-Model      Controller                  Cloud/Region                Version  SLA          Timestamp
-sdcore  microk8s-localhost  microk8s-classic/localhost  3.5.4    unsupported  08:08:50Z
+Model   Controller          Cloud/Region        Version  SLA          Timestamp
+sdcore  microk8s-localhost  microk8s/localhost  3.5.4    unsupported  11:06:36-05:00
 
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
-amf                       1.4.4    active       1  sdcore-amf-k8s            1.5/edge       707  10.152.183.176  no       
-ausf                      1.4.2    active       1  sdcore-ausf-k8s           1.5/edge       520  10.152.183.65   no       
-grafana-agent             0.32.1   waiting      1  grafana-agent-k8s         latest/stable   45  10.152.183.221  no       installing agent
-mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.92   no       Primary
-nms                       1.0.0    active       1  sdcore-nms-k8s            1.5/edge       580  10.152.183.141  no       
-nrf                       1.4.1    active       1  sdcore-nrf-k8s            1.5/edge       580  10.152.183.130  no       
-nssf                      1.4.1    active       1  sdcore-nssf-k8s           1.5/edge       462  10.152.183.62   no       
-pcf                       1.4.3    active       1  sdcore-pcf-k8s            1.5/edge       512  10.152.183.144  no       
-router                             active       1  sdcore-router-k8s         1.5/edge       341  10.152.183.218  no       
-self-signed-certificates           active       1  self-signed-certificates  latest/stable  155  10.152.183.33   no       
-smf                       1.5.2    active       1  sdcore-smf-k8s            1.5/edge       590  10.152.183.64   no       
-traefik                   v2.11.0  waiting      1  traefik-k8s               latest/stable  194  10.152.183.198  no       installing agent
-udm                       1.4.3    active       1  sdcore-udm-k8s            1.5/edge       489  10.152.183.31   no       
-udr                       1.4.1    active       1  sdcore-udr-k8s            1.5/edge       486  10.152.183.82   no       
-upf                       1.4.0    active       1  sdcore-upf-k8s            1.5/edge       591  10.152.183.164  no       
+amf                       1.5.1    active       1  sdcore-amf-k8s            1.5/stable     834  10.152.183.64   no
+ausf                      1.5.1    active       1  sdcore-ausf-k8s           1.5/stable     645  10.152.183.201  no
+grafana-agent             0.32.1   blocked      1  grafana-agent-k8s         latest/stable   45  10.152.183.80   no       logging-consumer: off, grafana-cloud-config: off
+mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.88   no
+nms                       1.0.0    active       1  sdcore-nms-k8s            1.5/stable     741  10.152.183.20   no
+nrf                       1.5.2    active       1  sdcore-nrf-k8s            1.5/stable     720  10.152.183.158  no
+nssf                      1.5.1    active       1  sdcore-nssf-k8s           1.5/stable     597  10.152.183.247  no
+pcf                       1.5.2    active       1  sdcore-pcf-k8s            1.5/stable     650  10.152.183.92   no
+router                             active       1  sdcore-router-k8s         1.5/stable     424  10.152.183.62   no
+self-signed-certificates           active       1  self-signed-certificates  latest/stable  155  10.152.183.193  no
+smf                       1.6.2    active       1  sdcore-smf-k8s            1.5/stable     745  10.152.183.53   no
+traefik                   2.11.0   error        1  traefik-k8s               latest/stable  199  10.152.183.104  no       hook failed: "certificates-relation-changed"
+udm                       1.5.1    active       1  sdcore-udm-k8s            1.5/stable     605  10.152.183.237  no
+udr                       1.6.1    active       1  sdcore-udr-k8s            1.5/stable     597  10.152.183.79   no
+upf                       1.5.0    active       1  sdcore-upf-k8s            1.5/stable     691  10.152.183.251  no
 
-Unit                         Workload  Agent  Address      Ports  Message
-amf/0*                       active    idle   10.1.10.181         
-ausf/0*                      active    idle   10.1.10.186         
-grafana-agent/0*             blocked   idle   10.1.10.133         grafana-cloud-config: off, logging-consumer: off
-mongodb/0*                   active    idle   10.1.10.155         Primary
-nms/0*                       active    idle   10.1.10.174         
-nrf/0*                       active    idle   10.1.10.151         
-nssf/0*                      active    idle   10.1.10.136         
-pcf/0*                       active    idle   10.1.10.146         
-router/0*                    active    idle   10.1.10.145         
-self-signed-certificates/0*  active    idle   10.1.10.141         
-smf/0*                       active    idle   10.1.10.154         
-traefik/0*                   error     idle   10.1.10.160         hook failed: "ingress-relation-changed"
-udm/0*                       active    idle   10.1.10.187         
-udr/0*                       active    idle   10.1.10.176         
-upf/0*                       active    idle   10.1.10.169
+Unit                         Workload  Agent  Address       Ports  Message
+amf/0*                       active    idle   10.1.213.193
+ausf/0*                      active    idle   10.1.213.236
+grafana-agent/0*             blocked   idle   10.1.213.248         logging-consumer: off, grafana-cloud-config: off
+mongodb/0*                   active    idle   10.1.213.252         Primary
+nms/0*                       active    idle   10.1.213.214
+nrf/0*                       active    idle   10.1.213.195
+nssf/0*                      active    idle   10.1.213.243
+pcf/0*                       active    idle   10.1.213.225
+router/0*                    active    idle   10.1.213.231
+self-signed-certificates/0*  active    idle   10.1.213.232
+smf/0*                       active    idle   10.1.213.229
+traefik/0*                   error     idle   10.1.213.208         hook failed: "certificates-relation-changed"
+udm/0*                       active    idle   10.1.213.203
+udr/0*                       active    idle   10.1.213.250
+upf/0*                       active    idle   10.1.213.200
+
+Offer  Application  Charm           Rev  Connected  Endpoint  Interface  Role
+amf    amf          sdcore-amf-k8s  834  0/0        fiveg-n2  fiveg_n2   provider
+upf    upf          sdcore-upf-k8s  685  0/0        fiveg_n3  fiveg_n3   provider
 ```
 
 ## 5. Configure the ingress
@@ -258,7 +262,7 @@ resource "juju_model" "ran-simulator" {
 }
 
 module "gnbsim" {
-  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
+  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform?ref=v1.5"
 
   model      = juju_model.ran-simulator.name
   depends_on = [module.sdcore-router]
@@ -330,14 +334,14 @@ ran    microk8s-localhost  microk8s/localhost  3.5.4    unsupported  12:18:26+02
 SAAS  Status  Store  URL
 amf   active  local  admin/sdcore.amf
 
-App     Version  Status  Scale  Charm              Channel   Rev  Address         Exposed  Message
-gnbsim  1.4.3    active      1  sdcore-gnbsim-k8s  1.5/edge  557  10.152.183.209  no       
+App     Version  Status  Scale  Charm              Channel     Rev  Address         Exposed  Message
+gnbsim  1.5.0    active      1  sdcore-gnbsim-k8s  1.5/stable  612  10.152.183.209  no
 
 Unit       Workload  Agent  Address       Ports  Message
 gnbsim/0*  active    idle   10.1.194.238         
 
 Offer   Application  Charm              Rev  Connected  Endpoint            Interface           Role
-gnbsim  gnbsim       sdcore-gnbsim-k8s  557  1/1        fiveg_gnb_identity  fiveg_gnb_identity  provider
+gnbsim  gnbsim       sdcore-gnbsim-k8s  612  1/1        fiveg_gnb_identity  fiveg_gnb_identity  provider
 ```
 
 ## 7. Configure the 5G core network through the Network Management System

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -614,7 +614,7 @@ data "juju_model" "gnbsim" {
 }
 
 module "gnbsim" {
-  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
+  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform?ref=v1.5"
 
   model = data.juju_model.gnbsim.name
   

--- a/examples/terraform/getting_started/main.tf
+++ b/examples/terraform/getting_started/main.tf
@@ -6,14 +6,14 @@ resource "juju_model" "sdcore" {
 }
 
 module "sdcore-router" {
-  source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform"
+  source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform?ref=v1.5"
 
   model      = juju_model.sdcore.name
   depends_on = [juju_model.sdcore]
 }
 
 module "sdcore" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s?ref=v1.5"
 
   model      = juju_model.sdcore.name
   depends_on = [module.sdcore-router]

--- a/examples/terraform/getting_started/ran.tf
+++ b/examples/terraform/getting_started/ran.tf
@@ -6,7 +6,7 @@ resource "juju_model" "ran-simulator" {
 }
 
 module "gnbsim" {
-  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
+  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform?ref=v1.5"
 
   model      = juju_model.ran-simulator.name
   depends_on = [module.sdcore-router]

--- a/examples/terraform/mastering/main.tf
+++ b/examples/terraform/mastering/main.tf
@@ -3,7 +3,7 @@ data "juju_model" "control-plane" {
 }
 
 module "sdcore-control-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-control-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-control-plane-k8s?ref=v1.5"
 
   model = data.juju_model.control-plane.name
 
@@ -22,7 +22,7 @@ data "juju_model" "user-plane" {
 }
 
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s?ref=v1.5"
 
   model = data.juju_model.user-plane.name
 
@@ -44,7 +44,7 @@ data "juju_model" "gnbsim" {
 }
 
 module "gnbsim" {
-  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
+  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform?ref=v1.5"
 
   model = data.juju_model.gnbsim.name
 
@@ -103,7 +103,7 @@ resource "juju_integration" "nms-upf" {
 }
 
 module "cos-lite" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite?ref=v1.5"
 
   model_name               = "cos-lite"
   deploy_cos_configuration = true


### PR DESCRIPTION
# Description

Update the documentation for the 1.5 release. This involves:

- Updating the URLs for Terraform modules to point to the release
- Updating the example juju status outputs to match
- Remove the OCI images size comparison as this is not true anymore 

This depends on the following PRs being merged, in this order:

1. https://github.com/canonical/sdcore-upf-k8s-operator/pull/435
2. https://github.com/canonical/sdcore-gnbsim-rock/pull/31
3. https://github.com/canonical/sdcore-gnbsim-k8s-operator/pull/366

Once those are merged, the UPF and GNBSIM charms will need to be promoted to stable.

# Checklist:

- [x] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
