### PR TITLE
docs: bump juju version to 3.6/stable

### DIFF
--- a/docs/how-to/deploy_sdcore_gnbsim.md
+++ b/docs/how-to/deploy_sdcore_gnbsim.md
@@ -4,7 +4,7 @@ This guide covers how to install and configure the SD-Core gNB Simulator.
 
 ## Requirements
 
-- Juju >= 3.5
+- Juju >= 3.6
 - A Juju controller has been bootstrapped
 - A Kubernetes cluster configured with Multus
 - 1 Juju cloud for the Kubernetes cluster has been added

--- a/docs/how-to/deploy_sdcore_standalone.md
+++ b/docs/how-to/deploy_sdcore_standalone.md
@@ -6,7 +6,7 @@ This guide covers how to install a standalone SD-Core 5G core network, suitable 
 
 You will need a Kubernetes cluster installed and configured with Multus.
 
-- Juju >= 3.5
+- Juju >= 3.6
 - Kubernetes >= 1.25
 - A `LoadBalancer` Service for Kubernetes with at least 3 addresses available
 - Multus

--- a/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
+++ b/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
@@ -18,7 +18,7 @@ Navigate between the tabs below to find the steps suitable for your setup (Kuber
   - `driverctl` installed
   - LoadBalancer with 1 available address for the UPF
   - Multus CNI enabled
-- Juju >= 3.5/stable
+- Juju >= 3.6/stable
 - A Juju controller bootstrapped onto the Kubernetes cluster
 - Terraform 
 
@@ -170,7 +170,7 @@ terraform apply -auto-approve
   - 3 network interfaces
   - `driverctl` installed
 - Juju host
-  - Juju>=3.5
+  - Juju>=3.6
   - Cloud of type `manual` created
 - Terraform
 

--- a/docs/how-to/troubleshoot_deployment_issues.md
+++ b/docs/how-to/troubleshoot_deployment_issues.md
@@ -65,7 +65,7 @@ $ juju controllers
 Use --refresh option with this command to see the latest information.
 
 Controller           Model      User   Access     Cloud/Region        Models  Nodes  HA  Version
-microk8s-localhost*  private5g  admin  superuser  microk8s/localhost       9      -   -  3.5.4  
+microk8s-localhost*  private5g  admin  superuser  microk8s/localhost       9      -   -  3.6.0  
 ```
 
 If your controller does not show up in the list, please follow [this guide][Bootstrap Juju Controller] to create a Juju controller.

--- a/docs/how-to/troubleshoot_user_plane_issues.md
+++ b/docs/how-to/troubleshoot_user_plane_issues.md
@@ -18,7 +18,7 @@ The UPF charm should be in `Active/Idle` status:
 
 ```shell
 Model      Controller                  Cloud/Region                Version  SLA          Timestamp
-private5g  microk8s-classic-localhost  microk8s-classic/localhost  3.5.4    unsupported  18:56:32Z
+private5g  microk8s-classic-localhost  microk8s-classic/localhost  3.6.0    unsupported  18:56:32Z
 
 App  Version  Status  Scale  Charm           Channel     Rev  Address         Exposed  Message
 upf  1.5.0    active      1  sdcore-upf-k8s  1.5/stable  622  10.152.183.236  no

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -52,7 +52,7 @@ sudo microk8s enable metallb:10.0.0.2-10.0.0.4
 From your terminal, install Juju.
 
 ```console
-sudo snap install juju --channel=3.5/stable
+sudo snap install juju --channel=3.6/stable
 ```
 
 Bootstrap a Juju controller
@@ -164,7 +164,7 @@ Example:
 ```console
 ubuntu@host:~$ juju status
 Model   Controller          Cloud/Region        Version  SLA          Timestamp
-sdcore  microk8s-localhost  microk8s/localhost  3.5.4    unsupported  11:06:36-05:00
+sdcore  microk8s-localhost  microk8s/localhost  3.6.0    unsupported  11:06:36-05:00
 
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
 amf                       1.5.1    active       1  sdcore-amf-k8s            1.5/stable     834  10.152.183.64   no
@@ -329,7 +329,7 @@ Example:
 ```console
 ubuntu@host:~/terraform $ juju status
 Model  Controller          Cloud/Region        Version  SLA          Timestamp
-ran    microk8s-localhost  microk8s/localhost  3.5.4    unsupported  12:18:26+02:00
+ran    microk8s-localhost  microk8s/localhost  3.6.0    unsupported  12:18:26+02:00
 
 SAAS  Status  Store  URL
 amf   active  local  admin/sdcore.amf

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -18,7 +18,7 @@ A machine running Ubuntu 22.04 with the following resources:
 The following IP networks will be used to connect and isolate the network functions:
 
 | Name         | Subnet        | Gateway IP |
-|--------------|---------------|------------|
+| ------------ | ------------- | ---------- |
 | `management` | 10.201.0.0/24 | 10.201.0.1 |
 | `access`     | 10.202.0.0/24 | 10.202.0.1 |
 | `core`       | 10.203.0.0/24 | 10.203.0.1 |
@@ -50,12 +50,12 @@ sudo snap install terraform --classic
 
 To complete this tutorial, you will need four virtual machines with access to the networks as follows:
 
-| Machine                              | CPUs | RAM  | Disk | Networks                       |
-|--------------------------------------|------|------|------|--------------------------------|
-| Control Plane Kubernetes Cluster     | 4    | 8g   | 40g  | `management`                   |
-| User Plane Kubernetes Cluster        | 4    | 12g  | 20g  | `management`, `access`, `core` |
-| Juju Controller + Kubernetes Cluster | 4    | 6g   | 40g  | `management`                   |
-| gNB Simulator Kubernetes Cluster     | 2    | 3g   | 20g  | `management`, `ran`            |
+| Machine                              | CPUs | RAM | Disk | Networks                       |
+| ------------------------------------ | ---- | --- | ---- | ------------------------------ |
+| Control Plane Kubernetes Cluster     | 4    | 8g  | 40g  | `management`                   |
+| User Plane Kubernetes Cluster        | 4    | 12g | 20g  | `management`, `access`, `core` |
+| Juju Controller + Kubernetes Cluster | 4    | 6g  | 40g  | `management`                   |
+| gNB Simulator Kubernetes Cluster     | 2    | 3g  | 20g  | `management`, `ran`            |
 
 The complete infrastructure can be created with Terraform using the following commands:
 
@@ -179,7 +179,7 @@ scp /tmp/user-plane-cluster.yaml juju-controller.mgmt:
 In this guide, the following network interfaces are available on the SD-Core `user-plane` VM:
 
 | Interface Name | Purpose                                                                                                                                                           |
-|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | enp5s0         | internal Kubernetes management interface. This maps to the `management` subnet.                                                                                   |
 | enp6s0         | core interface. This maps to the `core` subnet.                                                                                                                   |
 | enp7s0         | access interface. This maps to the `access` subnet. Note that internet egress is required here and routing tables are already set to route gNB generated traffic. |
@@ -239,7 +239,7 @@ scp /tmp/gnb-cluster.yaml juju-controller.mgmt:
 In this guide, the following network interfaces are available on the `gnbsim` VM:
 
 | Interface Name | Purpose                                                                         |
-|----------------|---------------------------------------------------------------------------------|
+| -------------- | ------------------------------------------------------------------------------- |
 | enp5s0         | internal Kubernetes management interface. This maps to the `management` subnet. |
 | enp6s0         | ran interface. This maps to the `ran` subnet.                                   |
 
@@ -295,7 +295,7 @@ This will expose the Juju controller on the first allocated MetalLB address:
 
 ```console
 mkdir -p ~/.local/share/juju
-sudo snap install juju --channel=3.5/stable
+sudo snap install juju --channel=3.6/stable
 juju bootstrap microk8s --config controller-service-type=loadbalancer sdcore
 ```
 
@@ -493,7 +493,7 @@ We will provide necessary configuration (please see the list of the config optio
 Lastly, we will expose the Software as a Service offer for the UPF.
 
 | Config Option         | Descriptions                                                                                      |
-|-----------------------|---------------------------------------------------------------------------------------------------|
+| --------------------- | ------------------------------------------------------------------------------------------------- |
 | access-gateway-ip     | The IP address of the gateway that knows how to route traffic from the UPF towards the gNB subnet |
 | access-interface      | The name of the MACVLAN interface on the Kubernetes host cluster to bridge to the `access` subnet |
 | access-ip             | The IP address for the UPF to use on the `access` subnet                                          |
@@ -592,7 +592,7 @@ We will provide necessary configuration (please see the list of the config optio
 Lastly, we will expose the Software as a Service offer for the simulator.
 
 | Config Option           | Descriptions                                                                                                                                  |
-|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | gnb-interface           | The name of the MACVLAN interface to use on the host                                                                                          |
 | gnb-ip-address          | The IP address to use on the gnb interface                                                                                                    |
 | icmp-packet-destination | The target IP address to ping. If there is no egress to the internet on your core network, any IP that is reachable from the UPF should work. |


### PR DESCRIPTION
# Description

Bump juju version to 3.6/stable in `main`. The same change was already done for the `v1.5` branch in #56 

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
