### PR TITLE
chore: update traefik unit initial error message

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -195,7 +195,7 @@ pcf/0*                       active    idle   10.1.213.225
 router/0*                    active    idle   10.1.213.231
 self-signed-certificates/0*  active    idle   10.1.213.232
 smf/0*                       active    idle   10.1.213.229
-traefik/0*                   error     idle   10.1.213.208         hook failed: "certificates-relation-changed"
+traefik/0*                   error     idle   10.1.213.208         hook failed: "ingress-relation-created"
 udm/0*                       active    idle   10.1.213.203
 udr/0*                       active    idle   10.1.213.250
 upf/0*                       active    idle   10.1.213.200


### PR DESCRIPTION
# Description

Traefik initial error message is `hook failed: "ingress-relation-created`. Updating this in the tutorial.

![image](https://github.com/user-attachments/assets/7117276d-8a46-48ce-bbfa-8906ef0bcaa6)

 

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
