### PR TITLE
fix: Add missing v1.5 refs in v1.5 documentation

### DIFF
--- a/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
+++ b/docs/how-to/deploy_sdcore_user_plane_in_dpdk_mode.md
@@ -119,7 +119,7 @@ mkdir terraform
 cd terraform
 cat << EOF > main.tf
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s?ref=v1.5"
 
   model = "user-plane"
 

--- a/docs/how-to/integrate_sdcore_with_observability.md
+++ b/docs/how-to/integrate_sdcore_with_observability.md
@@ -19,7 +19,7 @@ Update your solution Terraform module (here it's named `main.tf`):
 ```console
 cat << EOF > main.tf
 module "cos" {
-  source                   = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
+  source                   = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite?ref=v1.5"
   model_name               = "cos-lite"
   deploy_cos_configuration = true
   cos_configuration_config = {
@@ -85,13 +85,13 @@ resource "juju_model" "sdcore" {
 }
 
 module "sdcore" {
-  source                   = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-k8s"
+  source                   = "git::https://github.com/canonical/terraform-juju-sdcore-k8s//modules/sdcore-k8s?ref=v1.5"
   model_name               = juju_model.sdcore.name
   create_model             = false
 }
 
 module "cos" {
-  source                   = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
+  source                   = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite?ref=v1.5"
   model_name               = "cos-lite"
   deploy_cos_configuration = true
   cos_configuration_config = {

--- a/docs/tutorials/accelerated_networking.md
+++ b/docs/tutorials/accelerated_networking.md
@@ -291,7 +291,7 @@ Please replace the `access-interface-mac-address` and `core-interface-mac-addres
 cd terraform
 cat << EOF >> main.tf
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s?ref=v1.5"
 
   model = "user-plane"
 

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -366,7 +366,7 @@ data "juju_model" "control-plane" {
 }
 
 module "sdcore-control-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-control-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-control-plane-k8s?ref=v1.5"
 
   model = data.juju_model.control-plane.name
 
@@ -518,7 +518,7 @@ data "juju_model" "user-plane" {
 }
 
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s?ref=v1.5"
 
   model = data.juju_model.user-plane.name
 
@@ -785,7 +785,7 @@ Add `cos-lite` Terraform module to the `main.tf` file used in the previous steps
 ```console
 cat << EOF >> main.tf
 module "cos-lite" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite?ref=v1.5"
 
   model_name               = "cos-lite"
   deploy_cos_configuration = true


### PR DESCRIPTION
# Description

I noticed that the documentation on v1.5 was somehow missing some `refs` in the Terraform URLs, making the user deploy the development version instead of the intended stable 1.5 release.

This adds all missing `refs` to the modules URLs.

# Checklist:

- [x] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
