### PR TITLE
feat: Updates documentation after switching from fiveg_gnb_identity to fiveg_core_gnb

### DIFF
--- a/docs/how-to/integrate_sdcore_with_external_gnb.md
+++ b/docs/how-to/integrate_sdcore_with_external_gnb.md
@@ -29,30 +29,20 @@ Either create a new `.tf` file, or add the following content to you existing `ma
 ```console
 module "gnb01" {
   app_name   = "gnb01"
-  source     = "git::https://github.com/canonical/sdcore-gnb-integrator//terraform?ref=v1.5"
+  source     = "git::https://github.com/canonical/sdcore-gnb-integrator//terraform"
   model_name = "gnb-integration"
-  channel    = "1.5/stable"
-  config     = {
-    tac: B01F
-  }
-}
-
-resource "juju_offer" "gnb01-fiveg-gnb-identity" {
-  model            = "gnb-integration"
-  application_name = module.gnb01.app_name
-  endpoint         = module.gnb01.fiveg_gnb_identity_endpoint
 }
 
 resource "juju_integration" "nms-gnb01" {
-  model = "control-plane"
-
+  model = module.gnb01.model_name
+  
   application {
-    name     = module.sdcore-control-plane.nms_app_name
-    endpoint = module.sdcore-control-plane.fiveg_gnb_identity_endpoint
+    name     = module.gnb01.app_name
+    endpoint = module.gnb01.requires.fiveg_core_gnb
   }
 
   application {
-    offer_url = juju_offer.gnb01-fiveg-gnb-identity.url
+    offer_url = module.sdcore-control-plane.nms_fiveg_core_gnb_offer_url
   }
 }
 ```

--- a/docs/tutorials/accelerated_networking.md
+++ b/docs/tutorials/accelerated_networking.md
@@ -9,7 +9,7 @@ This builds upon the [Mastering](mastering.md) tutorial. Follow that tutorial un
 Log in to the `user-plane` VM:
 
 ```shell
-lxc exec user-plane --user 1000 -- bash -l
+lxc exec user-plane -- su --login ubuntu
 ```
 
 ### Enable HugePages in the User Plane VM
@@ -25,7 +25,7 @@ sudo reboot
 Log in to the `user-plane` VM again:
 
 ```shell
-lxc exec user-plane --user 1000 -- bash -l
+lxc exec user-plane -- su --login ubuntu
 ```
 
 #### Checkpoint 1: Are HugePages enabled ?

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -103,20 +103,20 @@ EOF
 Create a Terraform module containing the SD-Core 5G core network and a router:
 
 ```console
-cat << EOF > main.tf
+cat << EOF > core.tf
 resource "juju_model" "sdcore" {
   name = "sdcore"
 }
 
 module "sdcore-router" {
-  source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform?ref=v1.5"
+  source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform"
 
   model      = juju_model.sdcore.name
   depends_on = [juju_model.sdcore]
 }
 
 module "sdcore" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s?ref=v1.5"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
 
   model        = juju_model.sdcore.name
   depends_on = [module.sdcore-router]
@@ -167,42 +167,43 @@ Model   Controller          Cloud/Region        Version  SLA          Timestamp
 sdcore  microk8s-localhost  microk8s/localhost  3.6.0    unsupported  11:06:36-05:00
 
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
-amf                       1.5.1    active       1  sdcore-amf-k8s            1.5/stable     834  10.152.183.64   no
-ausf                      1.5.1    active       1  sdcore-ausf-k8s           1.5/stable     645  10.152.183.201  no
-grafana-agent             0.32.1   blocked      1  grafana-agent-k8s         latest/stable   45  10.152.183.80   no       logging-consumer: off, grafana-cloud-config: off
-mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.88   no
-nms                       1.0.0    active       1  sdcore-nms-k8s            1.5/stable     741  10.152.183.20   no
-nrf                       1.5.2    active       1  sdcore-nrf-k8s            1.5/stable     720  10.152.183.158  no
-nssf                      1.5.1    active       1  sdcore-nssf-k8s           1.5/stable     597  10.152.183.247  no
-pcf                       1.5.2    active       1  sdcore-pcf-k8s            1.5/stable     650  10.152.183.92   no
-router                             active       1  sdcore-router-k8s         1.5/stable     424  10.152.183.62   no
-self-signed-certificates           active       1  self-signed-certificates  latest/stable  155  10.152.183.193  no
-smf                       1.6.2    active       1  sdcore-smf-k8s            1.5/stable     745  10.152.183.53   no
-traefik                   2.11.0   error        1  traefik-k8s               latest/stable  199  10.152.183.104  no       hook failed: "certificates-relation-changed"
-udm                       1.5.1    active       1  sdcore-udm-k8s            1.5/stable     605  10.152.183.237  no
-udr                       1.6.1    active       1  sdcore-udr-k8s            1.5/stable     597  10.152.183.79   no
-upf                       1.5.0    active       1  sdcore-upf-k8s            1.5/stable     691  10.152.183.251  no
+amf                       1.6.1    active       1  sdcore-amf-k8s            1.6/edge       862  10.152.183.173  no       
+ausf                      1.5.1    active       1  sdcore-ausf-k8s           1.6/edge       672  10.152.183.247  no       
+grafana-agent             0.40.4   waiting      1  grafana-agent-k8s         latest/stable   80  10.152.183.204  no       installing agent
+mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.96   no       
+nms                       1.1.0    active       1  sdcore-nms-k8s            1.6/edge       790  10.152.183.84   no       
+nrf                       1.6.1    active       1  sdcore-nrf-k8s            1.6/edge       747  10.152.183.132  no       
+nssf                      1.5.1    active       1  sdcore-nssf-k8s           1.6/edge       628  10.152.183.91   no       
+pcf                       1.5.2    active       1  sdcore-pcf-k8s            1.6/edge       669  10.152.183.129  no       
+router                             active       1  sdcore-router-k8s         1.6/edge       436  10.152.183.203  no       
+self-signed-certificates           active       1  self-signed-certificates  latest/stable  155  10.152.183.219  no       
+smf                       1.6.2    active       1  sdcore-smf-k8s            1.6/edge       764  10.152.183.220  no       
+traefik                   2.11.0   waiting      1  traefik-k8s               latest/stable  203  10.152.183.27   no       installing agent
+udm                       1.5.1    active       1  sdcore-udm-k8s            1.6/edge       625  10.152.183.228  no       
+udr                       1.6.1    active       1  sdcore-udr-k8s            1.6/edge       612  10.152.183.141  no       
+upf                       1.4.0    active       1  sdcore-upf-k8s            1.6/edge       678  10.152.183.229  no       
 
 Unit                         Workload  Agent  Address       Ports  Message
-amf/0*                       active    idle   10.1.213.193
-ausf/0*                      active    idle   10.1.213.236
-grafana-agent/0*             blocked   idle   10.1.213.248         logging-consumer: off, grafana-cloud-config: off
-mongodb/0*                   active    idle   10.1.213.252         Primary
-nms/0*                       active    idle   10.1.213.214
-nrf/0*                       active    idle   10.1.213.195
-nssf/0*                      active    idle   10.1.213.243
-pcf/0*                       active    idle   10.1.213.225
-router/0*                    active    idle   10.1.213.231
-self-signed-certificates/0*  active    idle   10.1.213.232
-smf/0*                       active    idle   10.1.213.229
-traefik/0*                   error     idle   10.1.213.208         hook failed: "ingress-relation-created"
-udm/0*                       active    idle   10.1.213.203
-udr/0*                       active    idle   10.1.213.250
-upf/0*                       active    idle   10.1.213.200
+amf/0*                       active    idle   10.1.194.236         
+ausf/0*                      active    idle   10.1.194.243         
+grafana-agent/0*             blocked   idle   10.1.194.196         Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
+mongodb/0*                   active    idle   10.1.194.249         
+nms/0*                       active    idle   10.1.194.203         
+nrf/0*                       active    idle   10.1.194.247         
+nssf/0*                      active    idle   10.1.194.227         
+pcf/0*                       active    idle   10.1.194.224         
+router/0*                    active    idle   10.1.194.245         
+self-signed-certificates/0*  active    idle   10.1.194.225         
+smf/0*                       active    idle   10.1.194.255         
+traefik/0*                   error     idle   10.1.194.246         hook failed: "certificates-relation-changed"
+udm/0*                       active    idle   10.1.194.219         
+udr/0*                       active    idle   10.1.194.211         
+upf/0*                       active    idle   10.1.194.217         
 
-Offer  Application  Charm           Rev  Connected  Endpoint  Interface  Role
-amf    amf          sdcore-amf-k8s  834  0/0        fiveg-n2  fiveg_n2   provider
-upf    upf          sdcore-upf-k8s  685  0/0        fiveg_n3  fiveg_n3   provider
+Offer  Application  Charm           Rev  Connected  Endpoint        Interface       Role
+amf    amf          sdcore-amf-k8s  862  0/0        fiveg-n2        fiveg_n2        provider
+nms    nms          sdcore-nms-k8s  790  0/0        fiveg_core_gnb  fiveg_core_gnb  provider
+upf    upf          sdcore-upf-k8s  678  0/0        fiveg_n3        fiveg_n3        provider
 ```
 
 ## 5. Configure the ingress
@@ -223,10 +224,10 @@ traefik-lb                           LoadBalancer   10.152.183.142   10.0.0.4   
 In this tutorial, the IP is `10.0.0.4`. Please note it, as we will need it in the next step.
 
 Configure Traefik to use an external hostname. To do that, edit `traefik_config`
-in the `main.tf` file:
+in the `core.tf` file:
 
 ```
-:caption: main.tf
+:caption: core.tf
 (...)
 module "sdcore" {
   (...)
@@ -262,16 +263,10 @@ resource "juju_model" "ran-simulator" {
 }
 
 module "gnbsim" {
-  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform?ref=v1.5"
+  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
 
   model      = juju_model.ran-simulator.name
   depends_on = [module.sdcore-router]
-}
-
-resource "juju_offer" "gnbsim-fiveg-gnb-identity" {
-  model            = juju_model.ran-simulator.name
-  application_name = module.gnbsim.app_name
-  endpoint         = module.gnbsim.provides.fiveg_gnb_identity
 }
 
 resource "juju_integration" "gnbsim-amf" {
@@ -288,15 +283,15 @@ resource "juju_integration" "gnbsim-amf" {
 }
 
 resource "juju_integration" "gnbsim-nms" {
-  model = juju_model.sdcore.name
+  model = juju_model.ran-simulator.name
 
   application {
-    name     = module.sdcore.nms_app_name
-    endpoint = module.sdcore.fiveg_gnb_identity_endpoint
+    name     = module.gnbsim.app_name
+    endpoint = module.gnbsim.requires.fiveg_core_gnb
   }
 
   application {
-    offer_url = juju_offer.gnbsim-fiveg-gnb-identity.url
+    offer_url = module.sdcore.nms_fiveg_core_gnb_offer_url
   }
 }
 
@@ -322,7 +317,7 @@ juju switch ran
 watch -n 1 -c juju status --color --relations
 ```
 
-The deployment is ready when the `gnbsim` application is in the `Active/Idle` state.<br>
+The deployment is ready when the `gnbsim` application is in the `Waiting/Idle` state and the message is `Waiting for TAC and PLMNs configuration`.<br>
 
 Example:
 
@@ -333,15 +328,13 @@ ran    microk8s-localhost  microk8s/localhost  3.6.0    unsupported  12:18:26+02
 
 SAAS  Status  Store  URL
 amf   active  local  admin/sdcore.amf
+nms   active  local  admin/sdcore.nms
 
-App     Version  Status  Scale  Charm              Channel     Rev  Address         Exposed  Message
-gnbsim  1.5.0    active      1  sdcore-gnbsim-k8s  1.5/stable  612  10.152.183.209  no
+App     Version  Status   Scale  Charm              Channel   Rev  Address        Exposed  Message
+gnbsim  1.4.5    waiting      1  sdcore-gnbsim-k8s  1.6/edge  638  10.152.183.85  no       installing agent
 
 Unit       Workload  Agent  Address       Ports  Message
-gnbsim/0*  active    idle   10.1.194.238         
-
-Offer   Application  Charm              Rev  Connected  Endpoint            Interface           Role
-gnbsim  gnbsim       sdcore-gnbsim-k8s  612  1/1        fiveg_gnb_identity  fiveg_gnb_identity  provider
+gnbsim/0*  waiting   idle   10.1.194.239         Waiting for TAC and PLMNs configuration
 ```
 
 ## 7. Configure the 5G core network through the Network Management System
@@ -381,7 +374,7 @@ In the Network Management System (NMS), create a network slice with the followin
 - MCC: `001`
 - MNC: `01`
 - UPF: `upf-external.sdcore.svc.cluster.local:8805`
-- gNodeB: `sdcore-gnbsim-gnbsim`
+- gNodeB: `ran-gnbsim-gnbsim`
 
 You should see the following network slice created:
 
@@ -407,10 +400,36 @@ You should see the following subscriber created:
 
 ## 8. Run the 5G simulation
 
-Run the simulation:
+Switch to the `ran` model and make sure that the `gnbsim` appliacation is in `Active/Idle` state.
 
 ```console
 juju switch ran
+juju status
+```
+
+The output should be similar to below:
+
+Example:
+
+```console
+ubuntu@host:~/terraform $ juju status
+Model  Controller          Cloud/Region        Version  SLA          Timestamp
+ran    microk8s-localhost  microk8s/localhost  3.6.0    unsupported  12:18:26+02:00
+
+SAAS  Status  Store  URL
+amf   active  local  admin/sdcore.amf
+nms   active  local  admin/sdcore.nms
+
+App     Version  Status  Scale  Charm              Channel   Rev  Address        Exposed  Message
+gnbsim  1.4.5    active      1  sdcore-gnbsim-k8s  1.6/edge  638  10.152.183.85  no       
+
+Unit       Workload  Agent  Address       Ports  Message
+gnbsim/0*  active    idle   10.1.194.239
+```
+
+Run the simulation:
+
+```console
 juju run gnbsim/leader start-simulation
 ```
 
@@ -436,7 +455,7 @@ terraform destroy -auto-approve
 
 ```{note}
 Terraform does not remove anything from the working directory. If needed, please clean up
-the `terraform` directory manually by removing everything except for the `main.tf`
+the `terraform` directory manually by removing everything except for the `core.tf`
 and `terraform.tf` files.
 ```
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -400,7 +400,7 @@ You should see the following subscriber created:
 
 ## 8. Run the 5G simulation
 
-Switch to the `ran` model and make sure that the `gnbsim` appliacation is in `Active/Idle` state.
+Switch to the `ran` model and make sure that the `gnbsim` application is in `Active/Idle` state.
 
 ```console
 juju switch ran

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -195,7 +195,7 @@ pcf/0*                       active    idle   10.1.194.224
 router/0*                    active    idle   10.1.194.245         
 self-signed-certificates/0*  active    idle   10.1.194.225         
 smf/0*                       active    idle   10.1.194.255         
-traefik/0*                   error     idle   10.1.194.246         hook failed: "certificates-relation-changed"
+traefik/0*                   error     idle   10.1.194.246         hook failed: "ingress-relation-created"
 udm/0*                       active    idle   10.1.194.219         
 udr/0*                       active    idle   10.1.194.211         
 upf/0*                       active    idle   10.1.194.217         

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -107,7 +107,7 @@ This section covers installation of necessary tools on the VMs which are going t
 Login to the `control-plane` VM:
 
 ```console
-lxc exec control-plane --user 1000 -- bash -l
+lxc exec control-plane -- su --login ubuntu
 ```
 
 Install MicroK8s:
@@ -146,7 +146,7 @@ Log out of the VM.
 Log in to the `user-plane` VM:
 
 ```console
-lxc exec user-plane --user 1000 -- bash -l
+lxc exec user-plane -- su --login ubuntu
 ```
 
 Install MicroK8s, configure MetalLB to expose 1 IP address for the UPF (`10.201.0.200`) and enable the Multus plugin:
@@ -207,7 +207,7 @@ Log out of the VM.
 Log in to the `gnbsim` VM:
 
 ```console
-lxc exec gnbsim --user 1000 -- bash -l
+lxc exec gnbsim -- su --login ubuntu
 ```
 
 Install MicroK8s and add the Multus plugin:
@@ -263,7 +263,7 @@ Log out of the VM.
 Log in to the `juju-controller` VM:
 
 ```console
-lxc exec juju-controller --user 1000 -- bash -l
+lxc exec juju-controller -- su --login ubuntu
 ```
 
 Begin by installing MicroK8s to hold the Juju controller.

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -18,7 +18,7 @@ A machine running Ubuntu 22.04 with the following resources:
 The following IP networks will be used to connect and isolate the network functions:
 
 | Name         | Subnet        | Gateway IP |
-| ------------ | ------------- | ---------- |
+|--------------|---------------|------------|
 | `management` | 10.201.0.0/24 | 10.201.0.1 |
 | `access`     | 10.202.0.0/24 | 10.202.0.1 |
 | `core`       | 10.203.0.0/24 | 10.203.0.1 |
@@ -51,7 +51,7 @@ sudo snap install terraform --classic
 To complete this tutorial, you will need four virtual machines with access to the networks as follows:
 
 | Machine                              | CPUs | RAM | Disk | Networks                       |
-| ------------------------------------ | ---- | --- | ---- | ------------------------------ |
+|--------------------------------------|------|-----|------|--------------------------------|
 | Control Plane Kubernetes Cluster     | 4    | 8g  | 40g  | `management`                   |
 | User Plane Kubernetes Cluster        | 4    | 12g | 20g  | `management`, `access`, `core` |
 | Juju Controller + Kubernetes Cluster | 4    | 6g  | 40g  | `management`                   |
@@ -179,7 +179,7 @@ scp /tmp/user-plane-cluster.yaml juju-controller.mgmt:
 In this guide, the following network interfaces are available on the SD-Core `user-plane` VM:
 
 | Interface Name | Purpose                                                                                                                                                           |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | enp5s0         | internal Kubernetes management interface. This maps to the `management` subnet.                                                                                   |
 | enp6s0         | core interface. This maps to the `core` subnet.                                                                                                                   |
 | enp7s0         | access interface. This maps to the `access` subnet. Note that internet egress is required here and routing tables are already set to route gNB generated traffic. |
@@ -239,7 +239,7 @@ scp /tmp/gnb-cluster.yaml juju-controller.mgmt:
 In this guide, the following network interfaces are available on the `gnbsim` VM:
 
 | Interface Name | Purpose                                                                         |
-| -------------- | ------------------------------------------------------------------------------- |
+|----------------|---------------------------------------------------------------------------------|
 | enp5s0         | internal Kubernetes management interface. This maps to the `management` subnet. |
 | enp6s0         | ran interface. This maps to the `ran` subnet.                                   |
 
@@ -341,7 +341,7 @@ Create new folder called `terraform`:
 mkdir terraform
 ```
 
-Inside newly created `terraform` folder create a `terraform.tf` file:
+Inside newly created `terraform` folder create a `versions.tf` file:
 
 ```console
 cd terraform
@@ -493,7 +493,7 @@ We will provide necessary configuration (please see the list of the config optio
 Lastly, we will expose the Software as a Service offer for the UPF.
 
 | Config Option         | Descriptions                                                                                      |
-| --------------------- | ------------------------------------------------------------------------------------------------- |
+|-----------------------|---------------------------------------------------------------------------------------------------|
 | access-gateway-ip     | The IP address of the gateway that knows how to route traffic from the UPF towards the gNB subnet |
 | access-interface      | The name of the MACVLAN interface on the Kubernetes host cluster to bridge to the `access` subnet |
 | access-ip             | The IP address for the UPF to use on the `access` subnet                                          |
@@ -588,11 +588,10 @@ Log out of the `user-plane` VM.
 The following steps build on the Juju controller which was bootstrapped and knows how to manage the gNB Simulator Kubernetes cluster.
 
 First, we will add gNB Simulator to the Terraform module used in the previous steps.
-We will provide necessary configuration (please see the list of the config options with the description in the table below) for the application and integrate the simulator with previously exposed AMF offering.
-Lastly, we will expose the Software as a Service offer for the simulator.
+We will provide necessary configuration (please see the list of the config options with the description in the table below) for the application and integrate the simulator with the relevant 5G Core Network Functions (AMF, NMS and UPF).
 
 | Config Option           | Descriptions                                                                                                                                  |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
 | gnb-interface           | The name of the MACVLAN interface to use on the host                                                                                          |
 | gnb-ip-address          | The IP address to use on the gnb interface                                                                                                    |
 | icmp-packet-destination | The target IP address to ping. If there is no egress to the internet on your core network, any IP that is reachable from the UPF should work. |
@@ -614,7 +613,7 @@ data "juju_model" "gnbsim" {
 }
 
 module "gnbsim" {
-  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform?ref=v1.5"
+  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
 
   model = data.juju_model.gnbsim.name
   
@@ -640,10 +639,30 @@ resource "juju_integration" "gnbsim-amf" {
   }
 }
 
-resource "juju_offer" "gnbsim-fiveg-gnb-identity" {
-  model            = data.juju_model.gnbsim.name
-  application_name = module.gnbsim.app_name
-  endpoint         = module.gnbsim.provides.fiveg_gnb_identity
+resource "juju_integration" "gnbsim-nms" {
+  model = data.juju_model.gnbsim.name
+
+  application {
+    name     = module.gnbsim.app_name
+    endpoint = module.gnbsim.requires.fiveg_core_gnb
+  }
+
+  application {
+    offer_url = module.sdcore-control-plane.nms_fiveg_core_gnb_offer_url
+  }
+}
+
+resource "juju_integration" "nms-upf" {
+  model = data.juju_model.control-plane.name
+
+  application {
+    name     = module.sdcore-control-plane.nms_app_name
+    endpoint = module.sdcore-control-plane.fiveg_n4_endpoint
+  }
+
+  application {
+    offer_url = module.sdcore-user-plane.upf_fiveg_n4_offer_url
+  }
 }
 
 EOF
@@ -667,53 +686,12 @@ Monitor the status of the deployment:
 juju status --watch 1s --relations
 ```
 
-The deployment is ready when the `gnbsim` application is in the `Active/Idle` state.
+The deployment is ready when the `gnbsim` application is in the `Waiting/Idle` state and the message is `Waiting for TAC and PLMNs configuration`.<br>
 
 ## 7. Configure SD-Core
 
 The following steps show how to configure the SD-Core 5G core network.
-
-We will start by creating integrations between the Network Management System (NMS) and the UPF and the gNB Simulator.
-Once the integrations are ready, we will create the core network configuration: a network slice, a device group and a subscriber.
-
-Add required integrations to the `main.tf` file used in the previous steps:
-
-```console
-cat << EOF >> main.tf
-resource "juju_integration" "nms-gnbsim" {
-  model = data.juju_model.control-plane.name
-
-  application {
-    name     = module.sdcore-control-plane.nms_app_name
-    endpoint = module.sdcore-control-plane.fiveg_gnb_identity_endpoint
-  }
-
-  application {
-    offer_url = juju_offer.gnbsim-fiveg-gnb-identity.url
-  }
-}
-
-resource "juju_integration" "nms-upf" {
-  model = data.juju_model.control-plane.name
-
-  application {
-    name     = module.sdcore-control-plane.nms_app_name
-    endpoint = module.sdcore-control-plane.fiveg_n4_endpoint
-  }
-
-  application {
-    offer_url = module.sdcore-user-plane.upf_fiveg_n4_offer_url
-  }
-}
-
-EOF
-```
-
-Apply the changes:
-
-```console
-terraform apply -auto-approve
-```
+In this step we will create a network slice, a device group and a subscriber.
 
 Retrieve the NMS credentials (`username` and `password`):
 

--- a/examples/terraform/getting_started/core.tf
+++ b/examples/terraform/getting_started/core.tf
@@ -6,14 +6,14 @@ resource "juju_model" "sdcore" {
 }
 
 module "sdcore-router" {
-  source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform?ref=v1.5"
+  source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform"
 
   model      = juju_model.sdcore.name
   depends_on = [juju_model.sdcore]
 }
 
 module "sdcore" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s?ref=v1.5"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
 
   model      = juju_model.sdcore.name
   depends_on = [module.sdcore-router]

--- a/examples/terraform/getting_started/ran.tf
+++ b/examples/terraform/getting_started/ran.tf
@@ -6,16 +6,10 @@ resource "juju_model" "ran-simulator" {
 }
 
 module "gnbsim" {
-  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform?ref=v1.5"
+  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
 
   model      = juju_model.ran-simulator.name
   depends_on = [module.sdcore-router]
-}
-
-resource "juju_offer" "gnbsim-fiveg-gnb-identity" {
-  model            = juju_model.ran-simulator.name
-  application_name = module.gnbsim.app_name
-  endpoint         = module.gnbsim.provides.fiveg_gnb_identity
 }
 
 resource "juju_integration" "gnbsim-amf" {
@@ -32,14 +26,14 @@ resource "juju_integration" "gnbsim-amf" {
 }
 
 resource "juju_integration" "gnbsim-nms" {
-  model = juju_model.sdcore.name
+  model = juju_model.ran-simulator.name
 
   application {
-    name     = module.sdcore.nms_app_name
-    endpoint = module.sdcore.fiveg_gnb_identity_endpoint
+    name     = module.gnbsim.app_name
+    endpoint = module.gnbsim.requires.fiveg_core_gnb
   }
 
   application {
-    offer_url = juju_offer.gnbsim-fiveg-gnb-identity.url
+    offer_url = module.sdcore.nms_fiveg_core_gnb_offer_url
   }
 }

--- a/examples/terraform/mastering/main.tf
+++ b/examples/terraform/mastering/main.tf
@@ -3,7 +3,7 @@ data "juju_model" "control-plane" {
 }
 
 module "sdcore-control-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-control-plane-k8s?ref=v1.5"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-control-plane-k8s"
 
   model = data.juju_model.control-plane.name
 
@@ -22,7 +22,7 @@ data "juju_model" "user-plane" {
 }
 
 module "sdcore-user-plane" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s?ref=v1.5"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-user-plane-k8s"
 
   model = data.juju_model.user-plane.name
 
@@ -44,7 +44,7 @@ data "juju_model" "gnbsim" {
 }
 
 module "gnbsim" {
-  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform?ref=v1.5"
+  source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
 
   model = data.juju_model.gnbsim.name
 
@@ -70,22 +70,16 @@ resource "juju_integration" "gnbsim-amf" {
   }
 }
 
-resource "juju_offer" "gnbsim-fiveg-gnb-identity" {
-  model            = data.juju_model.gnbsim.name
-  application_name = module.gnbsim.app_name
-  endpoint         = module.gnbsim.provides.fiveg_gnb_identity
-}
-
-resource "juju_integration" "nms-gnbsim" {
-  model = data.juju_model.control-plane.name
+resource "juju_integration" "gnbsim-nms" {
+  model = data.juju_model.gnbsim.name
 
   application {
-    name     = module.sdcore-control-plane.nms_app_name
-    endpoint = module.sdcore-control-plane.fiveg_gnb_identity_endpoint
+    name     = module.gnbsim.app_name
+    endpoint = module.gnbsim.requires.fiveg_core_gnb
   }
 
   application {
-    offer_url = juju_offer.gnbsim-fiveg-gnb-identity.url
+    offer_url = module.sdcore-control-plane.nms_fiveg_core_gnb_offer_url
   }
 }
 
@@ -103,7 +97,7 @@ resource "juju_integration" "nms-upf" {
 }
 
 module "cos-lite" {
-  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite?ref=v1.5"
+  source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
 
   model_name               = "cos-lite"
   deploy_cos_configuration = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lxd = {
       source = "terraform-lxd/lxd"
-      version = "2.1.0"
+      version = "2.4.0"
     }
   }
 }


### PR DESCRIPTION
# Description

- Replaces `fiveg_gnb_identity` with `fiveg_core_gnb`
- Removes references to `v1.5` release branch
- Fixes `not a snap cgroup` issue when accessing lxc machines
- Bumps version of the `terraform-lxd` provider to the latest one

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
