### PR TITLE
docs: separate uplink and downlink performance tests

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -34,6 +34,7 @@ CSR
 deployable
 DHCP
 DN
+Downlink
 DPDK
 dns
 dnsmasq
@@ -88,6 +89,7 @@ lxd
 LXD
 MACVLAN
 mbit
+Mbps
 MCC
 MetalLB
 mgmt
@@ -162,6 +164,7 @@ unsecure
 upf
 UPF
 UPFs
+Uplink
 vCPUs
 VFIO
 vfio

--- a/docs/how-to/test_upf_performance.md
+++ b/docs/how-to/test_upf_performance.md
@@ -173,10 +173,10 @@ iperf Done.
 
 ### Downlink
 
-On the `gnbsim` terminal, run the `iperf3` client:
+On the `gnbsim` terminal, run the `iperf3` client with the `-R` flag:
 
 ```console
-iperf3 -c <IP address of the host> --bind-dev uesimtun0
+iperf3 -c <IP address of the host> --bind-dev uesimtun0 -R
 ```
 
 You should see the throughput reported. For example:

--- a/docs/how-to/test_upf_performance.md
+++ b/docs/how-to/test_upf_performance.md
@@ -207,6 +207,6 @@ iperf Done.
 
 ### Summary
 
-The results above show the throughput of the connection between the UE and the host. In this case:
-- **Uplink**: 7.23 Mbits/sec
-- **Downlink**: 191 Mbits/sec
+The results above show the throughput of the connection between the UE and the host, going through the UPF. In this case, the results are:
+- **Uplink**: 7.23 Mbps/sec
+- **Downlink**: 191 Mbps/sec

--- a/docs/how-to/test_upf_performance.md
+++ b/docs/how-to/test_upf_performance.md
@@ -13,7 +13,7 @@ You will also require a machine on the data network to run the `iperf3` server.
 Log in to the `juju-controller` VM:
 
 ```console
-lxc exec juju-controller --user 1000 -- bash -l
+lxc exec juju-controller -- su --login ubuntu
 ```
 
 Disable the GNB simulator temporarily:
@@ -126,7 +126,7 @@ ping -I uesimtun0 <IP address of the host>
 
 ## Run performance test
 
-On the host, start an `iperf3` server:
+On the host, install `iperf3` and start an `iperf3` server:
 
 ```console
 sudo apt update
@@ -134,8 +134,79 @@ sudo apt install iperf3
 iperf3 -s
 ```
 
+```{note}
+You may need to use a different port if the default port is already in use.
+```
+
+### Uplink
+
 On the `gnbsim` terminal, run the `iperf3` client:
 
 ```console
 iperf3 -c <IP address of the host> --bind-dev uesimtun0
 ```
+
+You should see the throughput reported. For example:
+
+```console
+ubuntu@gnbsim:~$ iperf3 -c 10.42.0.13 -p 1234 --bind-dev uesimtun0
+Connecting to host 10.42.0.13, port 1234
+[  5] local 172.250.0.5 port 59850 connected to 10.42.0.13 port 1234
+[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5]   0.00-1.00   sec   512 KBytes  4.19 Mbits/sec  132   10.5 KBytes       
+[  5]   1.00-2.00   sec   384 KBytes  3.14 Mbits/sec   67   6.58 KBytes       
+[  5]   2.00-3.00   sec   640 KBytes  5.24 Mbits/sec   77   3.95 KBytes       
+[  5]   3.00-4.00   sec  2.12 MBytes  17.8 Mbits/sec  213   2.63 KBytes       
+[  5]   4.00-5.00   sec  2.50 MBytes  21.0 Mbits/sec  189   2.63 KBytes       
+[  5]   5.00-6.00   sec   768 KBytes  6.30 Mbits/sec  124   3.95 KBytes       
+[  5]   6.00-7.00   sec   512 KBytes  4.19 Mbits/sec   84   3.95 KBytes       
+[  5]   7.00-8.00   sec   384 KBytes  3.15 Mbits/sec   71   9.21 KBytes       
+[  5]   8.00-9.00   sec   384 KBytes  3.15 Mbits/sec  117   1.32 KBytes       
+[  5]   9.00-10.00  sec   512 KBytes  4.19 Mbits/sec   76   10.5 KBytes       
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Retr
+[  5]   0.00-10.00  sec  8.62 MBytes  7.23 Mbits/sec  1150             sender
+[  5]   0.00-10.00  sec  8.25 MBytes  6.92 Mbits/sec                  receiver
+
+iperf Done.
+```
+
+### Downlink
+
+On the `gnbsim` terminal, run the `iperf3` client:
+
+```console
+iperf3 -c <IP address of the host> --bind-dev uesimtun0
+```
+
+You should see the throughput reported. For example:
+
+```console
+ubuntu@gnbsim:~$ iperf3 -c 10.42.0.13 -p 1234 --bind-dev uesimtun0 -R
+Connecting to host 10.42.0.13, port 1234
+Reverse mode, remote host 10.42.0.13 is sending
+[  5] local 172.250.0.5 port 52354 connected to 10.42.0.13 port 1234
+[ ID] Interval           Transfer     Bitrate
+[  5]   0.00-1.00   sec  23.0 MBytes   193 Mbits/sec                  
+[  5]   1.00-2.00   sec  22.9 MBytes   192 Mbits/sec                  
+[  5]   2.00-3.00   sec  21.8 MBytes   183 Mbits/sec                  
+[  5]   3.00-4.00   sec  22.8 MBytes   191 Mbits/sec                  
+[  5]   4.00-5.00   sec  23.0 MBytes   193 Mbits/sec                  
+[  5]   5.00-6.00   sec  23.0 MBytes   193 Mbits/sec                  
+[  5]   6.00-7.00   sec  22.8 MBytes   191 Mbits/sec                  
+[  5]   7.00-8.00   sec  22.8 MBytes   191 Mbits/sec                  
+[  5]   8.00-9.00   sec  23.1 MBytes   194 Mbits/sec                  
+[  5]   9.00-10.00  sec  22.9 MBytes   192 Mbits/sec                  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Retr
+[  5]   0.00-10.00  sec   228 MBytes   191 Mbits/sec  20524             sender
+[  5]   0.00-10.00  sec   228 MBytes   191 Mbits/sec                  receiver
+
+iperf Done.
+```
+
+### Summary
+
+The results above show the throughput of the connection between the UE and the host. In this case:
+- **Uplink**: 7.23 Mbits/sec
+- **Downlink**: 191 Mbits/sec


### PR DESCRIPTION
# Description

The existing how-to guide on running performance tests only validated uplink throughput. Here we add a validation for the downlink throughput. 

We also leverage this opportunity to address a minor issue with exec into the vm's.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
