### PR TITLE
fix: fix file name in tutorials

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -84,7 +84,7 @@ On the host machine create a new directory called `terraform`:
 mkdir terraform
 ```
 
-Inside newly created `terraform` directory create a `terraform.tf` file:
+Inside newly created `terraform` directory create a `versions.tf` file:
 
 ```console
 cd terraform
@@ -455,8 +455,8 @@ terraform destroy -auto-approve
 
 ```{note}
 Terraform does not remove anything from the working directory. If needed, please clean up
-the `terraform` directory manually by removing everything except for the `core.tf`
-and `terraform.tf` files.
+the `terraform` directory manually by removing everything except for the `core.tf`, `ran.tf`
+and `versions.tf` files.
 ```
 
 Destroy the Juju controller and all its models:

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -1162,7 +1162,7 @@ terraform destroy -auto-approve
 
 ```{note}
 Terraform does not remove anything from the working directory.
-If needed, please clean up the `terraform` directory manually by removing everything except for the `main.tf` and `terraform.tf` files.
+If needed, please clean up the `terraform` directory manually by removing everything except for the `main.tf` and `versions.tf` files.
 ```
 
 


### PR DESCRIPTION
# Description

The `terraform.tf` file does not exist anymore (https://github.com/canonical/charmed-aether-sd-core/pull/42/files) 
This PR replaces `terraform.tf` with `version.tf` in the tutorials.
This is a fix for https://github.com/canonical/charmed-aether-sd-core/issues/74

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
