### PR TITLE
fix: backport small fixes in tutorials

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -84,7 +84,7 @@ On the host machine create a new directory called `terraform`:
 mkdir terraform
 ```
 
-Inside newly created `terraform` directory create a `terraform.tf` file:
+Inside newly created `terraform` directory create a `versions.tf` file:
 
 ```console
 cd terraform
@@ -436,8 +436,8 @@ terraform destroy -auto-approve
 
 ```{note}
 Terraform does not remove anything from the working directory. If needed, please clean up
-the `terraform` directory manually by removing everything except for the `main.tf`
-and `terraform.tf` files.
+the `terraform` directory manually by removing everything except for the `main.tf`, `ran.tf`
+and `versions.tf` files.
 ```
 
 Destroy the Juju controller and all its models:

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -343,7 +343,7 @@ Create new folder called `terraform`:
 mkdir terraform
 ```
 
-Inside newly created `terraform` folder create a `terraform.tf` file:
+Inside newly created `terraform` folder create a `versions.tf` file:
 
 ```console
 cd terraform
@@ -1051,5 +1051,5 @@ terraform destroy -auto-approve
 
 ```{note}
 Terraform does not remove anything from the working directory.
-If needed, please clean up the `terraform` directory manually by removing everything except for the `main.tf` and `terraform.tf` files.
+If needed, please clean up the `terraform` directory manually by removing everything except for the `main.tf` and `versions.tf` files.
 ```

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -435,7 +435,7 @@ We will need them shortly.
 If the IP for the AMF is not `10.201.0.52`, you will need to update the DNS entry. In the host,
 edit the `main.tf` file. Find the following line and set it to the right IP address, like so:
 
-`host-record=amf.mgmt,10.201.0.53`
+`host-record=amf.mgmt,10.201.0.52`
 
 Then, run the following command on the host:
 


### PR DESCRIPTION
# Description

This is a backport of https://github.com/canonical/charmed-aether-sd-core/pull/77 and https://github.com/canonical/charmed-aether-sd-core/pull/80 

This is a fix for https://github.com/canonical/charmed-aether-sd-core/issues/74 and https://github.com/canonical/charmed-aether-sd-core/issues/75

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
