### PR TITLE
fix: remove duplicate ci jobs

### DIFF
--- a/.github/workflows/automatic-check.yml
+++ b/.github/workflows/automatic-check.yml
@@ -1,8 +1,12 @@
 name: Automatic documentation checks
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - v1.5
+  pull_request:
+    branches:
+      - v1.5
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# Description

This change makes the CI trigger only on PR events, and not on push. This will prevent duplicate runs of CI jobs.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
