### PR TITLE
fix: fix AMF IP manual set in mastering tutorial

### DIFF
--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -594,7 +594,7 @@ We will need them shortly.
 If the IP for the AMF is not `10.201.0.52`, you will need to update the DNS entry. In the host,
 edit the `main.tf` file. Find the following line and set it to the right IP address, like so:
 
-`host-record=amf.mgmt,10.201.0.53`
+`host-record=amf.mgmt,10.201.0.52`
 
 Then, run the following command on the host:
 

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -591,10 +591,9 @@ Note both IPs - in this case `10.201.0.52` for the AMF and `10.201.0.53` for Tra
 We will need them shortly.
 
 ```{note}
-If the IP for the AMF is not `10.201.0.52`, you will need to update the DNS entry. In the host,
-edit the `main.tf` file. Find the following line and set it to the right IP address, like so:
+If the IP for the AMF is not `10.201.0.52`, you will need to update the DNS entry to match the actual external IP for the AMF. In the host, edit the `main.tf` file. Find the following line and set it to the correct IP address, like so:
 
-`host-record=amf.mgmt,10.201.0.52`
+`host-record=amf.mgmt,10.201.0.53`
 
 Then, run the following command on the host:
 


### PR DESCRIPTION
# Description

https://github.com/canonical/charmed-aether-sd-core/issues/75 is not an actual problem but the phrasing can be confusing. This PR clarifies the step.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
