### PR TITLE
chore: Removes note about Traefik's bug

### DIFF
--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -403,7 +403,6 @@ juju status --watch 1s --relations
 
 The deployment is ready when all the charms are in the `Active/Idle` state.<br>
 It is normal for `grafana-agent` to remain in waiting state.<br>
-It is also expected that `traefik` goes to the error state (related Traefik [bug](https://github.com/canonical/traefik-k8s-operator/issues/361)).
 
 Once the deployment is ready, we will proceed to the configuration part.
 


### PR DESCRIPTION
# Description

After releasing new version of Traefik to stable, the note about Traefik's bug is no longer needed.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
