### PR TITLE
chore: add juju and K8s versions

### DIFF
--- a/docs/how-to/deploy_sdcore_cups.md
+++ b/docs/how-to/deploy_sdcore_cups.md
@@ -4,12 +4,12 @@ This guide covers how to install a SD-Core 5G core network with Control Plane an
 
 ## Requirements
 
-- Juju >= 3.5
+- Juju >= 3.6
 - A Juju controller has been bootstrapped, and is externally reachable
-- A Control Plane Kubernetes cluster configured with
+- A Control Plane Kubernetes cluster (version >= 1.25) configured with
   - 1 available IP address for the Access and Mobility Management Function (AMF)
   - 1 available IP address for Traefik
-- A User Plane Kubernetes cluster configured with
+- A User Plane Kubernetes cluster (version >= 1.25) configured with
   - 1 available IP address for the User Plane Function (UPF)
   - Multus
   - MACVLAN interfaces for Access and Core networks

--- a/docs/how-to/deploy_sdcore_standalone.md
+++ b/docs/how-to/deploy_sdcore_standalone.md
@@ -16,12 +16,12 @@ You will need a Kubernetes cluster installed and configured with Multus.
 ## Deploy
 
 Get Charmed Aether SD-Core Terraform modules by cloning the [Charmed Aether SD-Core Terraform modules][Charmed Aether SD-Core Terraform modules] Git repository.
-Inside the `modules/sdcore-k8s` directory, create a `terraform.tfvars` file to set the name of Juju model for the deployment:
+Inside the `modules/sdcore-k8s` directory, create a `variables.tfvars` file to set the name of Juju model for the deployment:
 
 ```console
 git clone https://github.com/canonical/terraform-juju-sdcore.git
 cd terraform-juju-sdcore/modules/sdcore-k8s
-cat << EOF > terraform.tfvars
+cat << EOF > variables.tfvars
 model = "<YOUR_JUJU_MODEL_NAME>"
 EOF
 ```
@@ -35,7 +35,7 @@ terraform init
 Deploy 5G network.
 
 ```console
-terraform apply -var-file="terraform.tfvars" -auto-approve
+terraform apply -var-file="variables.tfvars" -auto-approve
 ```
 
 The deployment process should take approximately 15-20 minutes.
@@ -59,7 +59,7 @@ To view all the available configuration options, please inspect the `variables.t
 To be effective, every configuration change needs to be applied using the following command:
 
 ```console
-terraform apply -var-file="terraform.tfvars" -auto-approve
+terraform apply -var-file="variables.tfvars" -auto-approve
 ```
 
 [Charmed Aether SD-Core Terraform modules]: https://github.com/canonical/terraform-juju-sdcore


### PR DESCRIPTION
# Description

Add Juju and K8s version
Replace terraform.tfvars -> variables.tfvars as suggested by CC006.

Fixes https://github.com/canonical/charmed-aether-sd-core/issues/86.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
