### PR TITLE
docs: add af_packet performance results

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -78,6 +78,7 @@ integrations
 integrator
 IOMMU
 IOV
+iPerf
 jq
 juju
 Juju

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -8,11 +8,11 @@
 | --------------------- | --------- | --------    | ---------  | ---------  |
 | UERANSIM              | DPDK      | vfioveth    | 962 Mbps   | 957 Mbps   |
 | UERANSIM              | AF_PACKET | bridge      | 7.8 Mbps   | 823.8 Mbps |
-| UERANSIM              | AF_PACKET | macvlan     | 8.27 Mbps  | 958 Mbps   |
+| UERANSIM              | AF_PACKET | MACVLAN     | 8.27 Mbps  | 958 Mbps   |
 | UERANSIM              | AF_PACKET | host-device | 8 Mbps     | 957.2 Mbps |
 | Quectel RM520N-GL     | DPDK      | vfioveth    | 79.8 Mbps  | 12.5 Mbps  |
 | Quectel RM520N-GL     | AF_PACKET | bridge      | 0.741 Mbps | 11.7 Mbps  |
-| Quectel RM520N-GL     | AF_PACKET | macvlan     | 0.748 Mbps | 12.8 Mbps  |
+| Quectel RM520N-GL     | AF_PACKET | MACVLAN     | 0.748 Mbps | 12.8 Mbps  |
 | Quectel RM520N-GL     | AF_PACKET | host-device | 0.739 Mbps | 12.46 Mbps |
 
 ### Methodology

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -8,8 +8,10 @@
 | --------------------- | --------- | -------- | ---------  | ---------  |
 | UERANSIM              | DPDK      | vfioveth | 962 Mbps   | 957 Mbps   |
 | UERANSIM              | AF_PACKET | bridge   | 7.8 Mbps   | 823.8 Mbps |
+| UERANSIM              | AF_PACKET | macvlan  | 8.27 Mbps  | 958 Mbps   |
 | OAI UE (Over the air) | DPDK      | vfioveth | 79.8 Mbps  | 12.5 Mbps  |
 | OAI UE (Over the air) | AF_PACKET | bridge   | 0.741 Mbps | 11.7 Mbps  |
+| OAI UE (Over the air) | AF_PACKET | macvlan  | 0.748 Mbps | 12.8 Mbps  |
 
 ### Methodology
 

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -27,12 +27,22 @@ results.
 
 #### UPF Host
 
+Hardware:
+- CPU: Intel i5-1240P
+- RAM: 32 GB DDR5
+- Network cards: Intel 82599ES 10-Gigabit SFI/SFP+
+
 Software:
 - OS: Ubuntu 24.04
 - Kubernetes: microk8s 1.31.3
 - sdcore-upf-k8s: 1.5/stable; revision 691
 
 #### RAN Host
+
+Hardware:
+- CPU: Intel i5-1240P
+- RAM: 16 GB DDR5
+- Network cards: Intel 82599ES 10-Gigabit SFI/SFP+
 
 Software:
 - OS: Ubuntu 24.04

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -2,31 +2,34 @@
 
 ## UPF throughput
 
-### Test setup
+### Results
 
-The UPF performance results presented here were tested on real hardware. The
-computer used had the following specifications:
+| UE Type               | UPF Mode  | Downlink  | Uplink    |
+| --------------------- | --------- | --------- | --------- |
+| UERANSIM              | DPDK      | 962 Mbps  | 957 Mbps  |
+| OAI UE (Over the air) | DPDK      | 79.8 Mbps | 12.5 Mbps |
+| UERANSIM              | AF_PACKET | 6.146     | 268.2     |
 
-- CPU: Intel i5-1240P
-- RAM: 32 GB DDR5
-- Network cards: Intel 82599ES 10-Gigabit SFI/SFP+
+### Methodology
 
-The software consisted of:
+Tests were performed using `iperf3` to measure the throughput between the
+UE and an iPerf3 server going through the UPF.
 
+The tests results were obtained by running each test 5 times and averaging the
+results.
+
+#### Environment
+
+#### UPF Host
+
+Software:
 - OS: Ubuntu 24.04
 - Kubernetes: microk8s 1.31.3
 - sdcore-upf-k8s: 1.5/stable; revision 691
 
-The UPF was running in DPDK mode, with the network cards passed through SR-IOV.
+#### RAN Host
 
-#### RAN Host Specifications
-
-- CPU: Intel i5-1240P
-- RAM: 16 GB DDR5
-- Network cards: Intel 82599ES 10-Gigabit SFI/SFP+
-
-The software consisted of:
-
+Software:
 - OS: Ubuntu 24.04
 - Kubernetes: microk8s 1.31.3
 
@@ -46,18 +49,3 @@ with a bandwidth of 40 MHz. The radio unit used was a USRP B210 and the UE modul
 was a Quectel RM520N-GL over USB.
 
 This test is limited by the radio link configuration.
-
-### Results
-
-The tests results were obtained by running each test 5 times and averaging the
-results.
-
-#### UERANSIM simulator
-
-- Uplink: 957 Mbps
-- Downlink: 962 Mbps
-
-#### Over the air with OpenAirInterface
-
-- Uplink: 12.5 Mbps
-- Downlink: 79.8 Mbps

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -4,11 +4,12 @@
 
 ### Results
 
-| UE Type               | UPF Mode  | Downlink  | Uplink    |
-| --------------------- | --------- | --------- | --------- |
-| UERANSIM              | DPDK      | 962 Mbps  | 957 Mbps  |
-| OAI UE (Over the air) | DPDK      | 79.8 Mbps | 12.5 Mbps |
-| UERANSIM              | AF_PACKET | 39.1 Mbps | 932 Mbps  |
+| UE Type               | UPF Mode  | CNI Type | Downlink   | Uplink     |
+| --------------------- | --------- | -------- | ---------  | ---------  |
+| UERANSIM              | DPDK      | vfioveth | 962 Mbps   | 957 Mbps   |
+| UERANSIM              | AF_PACKET | bridge   | 7.8 Mbps   | 823.8 Mbps |
+| OAI UE (Over the air) | DPDK      | vfioveth | 79.8 Mbps  | 12.5 Mbps  |
+| OAI UE (Over the air) | AF_PACKET | bridge   | 0.741 Mbps | 11.7 Mbps  |
 
 ### Methodology
 

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -4,14 +4,16 @@
 
 ### Results
 
-| UE Type               | UPF Mode  | CNI Type | Downlink   | Uplink     |
-| --------------------- | --------- | -------- | ---------  | ---------  |
-| UERANSIM              | DPDK      | vfioveth | 962 Mbps   | 957 Mbps   |
-| UERANSIM              | AF_PACKET | bridge   | 7.8 Mbps   | 823.8 Mbps |
-| UERANSIM              | AF_PACKET | macvlan  | 8.27 Mbps  | 958 Mbps   |
-| OAI UE (Over the air) | DPDK      | vfioveth | 79.8 Mbps  | 12.5 Mbps  |
-| OAI UE (Over the air) | AF_PACKET | bridge   | 0.741 Mbps | 11.7 Mbps  |
-| OAI UE (Over the air) | AF_PACKET | macvlan  | 0.748 Mbps | 12.8 Mbps  |
+| UE Type               | UPF Mode  | CNI Type    | Downlink   | Uplink     |
+| --------------------- | --------- | --------    | ---------  | ---------  |
+| UERANSIM              | DPDK      | vfioveth    | 962 Mbps   | 957 Mbps   |
+| UERANSIM              | AF_PACKET | bridge      | 7.8 Mbps   | 823.8 Mbps |
+| UERANSIM              | AF_PACKET | macvlan     | 8.27 Mbps  | 958 Mbps   |
+| UERANSIM              | AF_PACKET | host-device | 8 Mbps     | 957.2 Mbps |
+| Quectel RM520N-GL     | DPDK      | vfioveth    | 79.8 Mbps  | 12.5 Mbps  |
+| Quectel RM520N-GL     | AF_PACKET | bridge      | 0.741 Mbps | 11.7 Mbps  |
+| Quectel RM520N-GL     | AF_PACKET | macvlan     | 0.748 Mbps | 12.8 Mbps  |
+| Quectel RM520N-GL     | AF_PACKET | host-device | 0.739 Mbps | 12.46 Mbps |
 
 ### Methodology
 

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -8,7 +8,7 @@
 | --------------------- | --------- | --------- | --------- |
 | UERANSIM              | DPDK      | 962 Mbps  | 957 Mbps  |
 | OAI UE (Over the air) | DPDK      | 79.8 Mbps | 12.5 Mbps |
-| UERANSIM              | AF_PACKET | 6.146     | 268.2     |
+| UERANSIM              | AF_PACKET | 39.1 Mbps | 932 Mbps  |
 
 ### Methodology
 


### PR DESCRIPTION
# Description

Here I re-structure the Performance reference so that results are at the top as those are likely what users will care the most about.

I added results from the AF_PACKET runs with different CNIs.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
