### PR TITLE
fix: typo in starting tutorial

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -272,7 +272,7 @@ resource "juju_integration" "gnbsim-nms" {
 
   application {
     name     = module.gnbsim.app_name
-    endpoint = module.gnbsim.requires.fiveg_core_gnbf
+    endpoint = module.gnbsim.requires.fiveg_core_gnb
   }
 
   application {


### PR DESCRIPTION
# Description

fix: typo in starting tutorial

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
