### PR TITLE
docs: add reference on testing

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -34,6 +34,7 @@ CPUs
 CSR
 DDR
 deployable
+deregister
 DHCP
 DN
 Downlink

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,4 +12,5 @@ public_clouds
 user_management
 release_notes/index
 performance
+testing
 ```

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,20 +1,20 @@
 # Testing
 
-Charmed Aether SD-Core is tested at different levels to ensure its correctness and performance. The tests are focused on the operational aspects of the solution - deploy, integrate, scale, upgrade.
+Charmed Aether SD-Core is tested at different levels to ensure its correctness and performance. The tests are focused on the operational aspects of the solution - deploy, configure, and integrate.
 
 ## Individual Charm tests
 
-- **Unit tests**: Each charm has a suite of unit tests that assert the correctness of the charm's behavior under different scenarios. Those tests are written using the [Scenario](https://github.com/canonical/ops-scenario) unit testing framework for charms. The tests are run automatically on each pull request. The tests are located in the `tests/unit/` directory of each charm. For example, the unit tests for the `sdcore-amf` charm are located [here](https://github.com/canonical/sdcore-amf-k8s-operator/tree/main/tests/unit).
-- **Integration tests**: Each charm has a suite of integration tests that deploy the charm in a Kubernetes cluster, alongside its dependencies, and assert that it behaves correctly. The tests are run automatically on each pull request. The tests are located in the `tests/integration/` directory of each charm. For example, the integration tests for the `sdcore-amf` charm are located [here](https://github.com/canonical/sdcore-amf-k8s-operator/tree/main/tests/integration).
+- **Unit tests**: Each charm has a suite of unit tests that assert the correctness of the charm's behavior under different scenarios. We write those tests using the [Scenario](https://github.com/canonical/ops-scenario) unit testing framework for charms. Each individual charm's Continuous Integration pipeline automatically tuns these tests on each pull request. You can find these tests under the `tests/unit/` directory of each charm. For example, the unit tests for the `sdcore-amf` charm are located [here](https://github.com/canonical/sdcore-amf-k8s-operator/tree/main/tests/unit).
+- **Integration tests**: Each charm has a suite of integration tests that deploy the charm in a Kubernetes cluster alongside its dependencies and assert that it behaves correctly. The tests are run automatically on each pull request. The tests are located in the `tests/integration/` directory of each charm. For example, the integration tests for the `sdcore-amf` charm are located [here](https://github.com/canonical/sdcore-amf-k8s-operator/tree/main/tests/integration).
 
 ## Solution tests
 
-- **end-to-end tests**: Charmed Aether SD-Core is tested as a whole using end-to-end tests that deploy the entire solution via Terraform in a Kubernetes cluster. Those tests also deploy a simulated RAN and UE using the [sdcore-gnbsim-k8s charm](https://github.com/canonical/sdcore-gnbsim-k8s-operator/) and run a series of tests that assesss that a subscriber can register, use the data plane, and deregister. The tests are run automatically once a day. The tests are located [here](https://github.com/canonical/sdcore-tests) and a dashboard of the test results is available [here]( https://canonical.github.io/sdcore-tests/).
+- **end-to-end tests**: Charmed Aether SD-Core is tested as a whole using end-to-end tests that deploy the entire solution via Terraform in a Kubernetes cluster. Those tests also deploy a simulated RAN and UE using the [sdcore-gnbsim-k8s charm](https://github.com/canonical/sdcore-gnbsim-k8s-operator/) and run a series of tests that assess that a subscriber can register, use the data plane, and deregister. The tests are run automatically once a day. The tests are located [here](https://github.com/canonical/sdcore-tests) and a dashboard of the test results is available [here]( https://canonical.github.io/sdcore-tests/).
 
 ## Performance tests
 
-Performance tests are run to assess the throughput of the solution under different scenarios. The tests are run manually once every release. More information about the performance tests can be found [here](performance.md).
+We run performance tests to assess the throughput of the solution under different scenarios. We run those tests manually once every release. You can learn more about performance tests [here](performance.md).
 
 ## A note on workload testing
 
-Charmed Aether SD-Core is a charmed distribution of Aether SD-Core. The focus of the testing is therefore on the charms themselves. If you are interested in learning more about how the 5G core is tested (ex. 3GPP procedures), please refer to the upstream project.
+Charmed Aether SD-Core is a charmed distribution of Aether SD-Core. The focus of the testing is therefore on the charms themselves - and not on the workload. If you are interested in learning more about how the underlying 5G core is tested (ex. 3GPP procedures), please refer to the upstream project.Charmed Aether SD-Core is a charmed distribution of Aether SD-Core. Therefore, the testing focuses on the charms themselves - and not on the workload. If you want to learn more about how the underlying 5G core is tested (ex., 3GPP procedures), please refer to the upstream project.

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -4,16 +4,16 @@ Charmed Aether SD-Core is tested at different levels to ensure its correctness a
 
 ## Individual Charm tests
 
-- **Unit tests**: Each charm has a suite of unit tests that assert the correctness of the charm's behavior under different scenarios. We write those tests using the [Scenario](https://github.com/canonical/ops-scenario) unit testing framework for charms. Each individual charm's Continuous Integration pipeline automatically tuns these tests on each pull request. You can find these tests under the `tests/unit/` directory of each charm. For example, the unit tests for the `sdcore-amf` charm are located [here](https://github.com/canonical/sdcore-amf-k8s-operator/tree/main/tests/unit).
+- **Unit tests**: Each charm has a suite of unit tests that assert the correctness of the charm's behavior under different scenarios. We write those tests using the [Scenario](https://github.com/canonical/ops-scenario) unit testing framework for charms. Each individual charm's Continuous Integration pipeline automatically runs these tests on each pull request. You can find these tests under the `tests/unit/` directory of each charm. For example, the unit tests for the `sdcore-amf` charm are located [here](https://github.com/canonical/sdcore-amf-k8s-operator/tree/main/tests/unit).
 - **Integration tests**: Each charm has a suite of integration tests that deploy the charm in a Kubernetes cluster alongside its dependencies and assert that it behaves correctly. The tests are run automatically on each pull request. The tests are located in the `tests/integration/` directory of each charm. For example, the integration tests for the `sdcore-amf` charm are located [here](https://github.com/canonical/sdcore-amf-k8s-operator/tree/main/tests/integration).
 
-## Solution tests
+## Product tests
 
-- **end-to-end tests**: Charmed Aether SD-Core is tested as a whole using end-to-end tests that deploy the entire solution via Terraform in a Kubernetes cluster. Those tests also deploy a simulated RAN and UE using the [sdcore-gnbsim-k8s charm](https://github.com/canonical/sdcore-gnbsim-k8s-operator/) and run a series of tests that assess that a subscriber can register, use the data plane, and deregister. The tests are run automatically once a day. The tests are located [here](https://github.com/canonical/sdcore-tests) and a dashboard of the test results is available [here]( https://canonical.github.io/sdcore-tests/).
+- **end-to-end tests**: Charmed Aether SD-Core is tested as a whole using end-to-end tests that deploy the entire product via Terraform in a Kubernetes cluster. Those tests also deploy a simulated RAN and UE using the [sdcore-gnbsim-k8s charm](https://github.com/canonical/sdcore-gnbsim-k8s-operator/) and run a series of tests that assess that a subscriber can register, use the data plane, and deregister. The tests are run automatically once a day. The tests are located [here](https://github.com/canonical/sdcore-tests) and a dashboard of the test results is available [here]( https://canonical.github.io/sdcore-tests/).
 
 ## Performance tests
 
-We run performance tests to assess the throughput of the solution under different scenarios. We run those tests manually once every release. You can learn more about performance tests [here](performance.md).
+We run performance tests to assess the User Plane throughput under different scenarios. We run those tests manually once every release. You can learn more about performance tests [here](performance.md).
 
 ## A note on workload testing
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -17,4 +17,4 @@ We run performance tests to assess the throughput of the solution under differen
 
 ## A note on workload testing
 
-Charmed Aether SD-Core is a charmed distribution of Aether SD-Core. The focus of the testing is therefore on the charms themselves - and not on the workload. If you are interested in learning more about how the underlying 5G core is tested (ex. 3GPP procedures), please refer to the upstream project.Charmed Aether SD-Core is a charmed distribution of Aether SD-Core. Therefore, the testing focuses on the charms themselves - and not on the workload. If you want to learn more about how the underlying 5G core is tested (ex., 3GPP procedures), please refer to the upstream project.
+Charmed Aether SD-Core is a charmed distribution of Aether SD-Core. Therefore, the testing focuses on the charms themselves - and not on their underlying workloads (ex. 5G network functions). If you want to learn more about how the underlying 5G core is tested (ex., 3GPP procedures), please refer to the upstream project.

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,0 +1,20 @@
+# Testing
+
+Charmed Aether SD-Core is tested at different levels to ensure its correctness and performance. The tests are focused on the operational aspects of the solution - deploy, integrate, scale, upgrade.
+
+## Individual Charm tests
+
+- **Unit tests**: Each charm has a suite of unit tests that assert the correctness of the charm's behavior under different scenarios. Those tests are written using the [Scenario](https://github.com/canonical/ops-scenario) unit testing framework for charms. The tests are run automatically on each pull request. The tests are located in the `tests/unit/` directory of each charm. For example, the unit tests for the `sdcore-amf` charm are located [here](https://github.com/canonical/sdcore-amf-k8s-operator/tree/main/tests/unit).
+- **Integration tests**: Each charm has a suite of integration tests that deploy the charm in a Kubernetes cluster, alongside its dependencies, and assert that it behaves correctly. The tests are run automatically on each pull request. The tests are located in the `tests/integration/` directory of each charm. For example, the integration tests for the `sdcore-amf` charm are located [here](https://github.com/canonical/sdcore-amf-k8s-operator/tree/main/tests/integration).
+
+## Solution tests
+
+- **end-to-end tests**: Charmed Aether SD-Core is tested as a whole using end-to-end tests that deploy the entire solution via Terraform in a Kubernetes cluster. Those tests also deploy a simulated RAN and UE using the [sdcore-gnbsim-k8s charm](https://github.com/canonical/sdcore-gnbsim-k8s-operator/) and run a series of tests that assesss that a subscriber can register, use the data plane, and deregister. The tests are run automatically once a day. The tests are located [here](https://github.com/canonical/sdcore-tests) and a dashboard of the test results is available [here]( https://canonical.github.io/sdcore-tests/).
+
+## Performance tests
+
+Performance tests are run to assess the throughput of the solution under different scenarios. The tests are run manually once every release. More information about the performance tests can be found [here](performance.md).
+
+## A note on workload testing
+
+Charmed Aether SD-Core is a charmed distribution of Aether SD-Core. The focus of the testing is therefore on the charms themselves. If you are interested in learning more about how the 5G core is tested (ex. 3GPP procedures), please refer to the upstream project.


### PR DESCRIPTION
# Description

During a discussion with @solmyrcan , he mentioned that a potential user would be interested in knowing more about how we test our solution. This document provides a reference on the various types of tests that are performed on Charmed Aether SD-Core.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
