### PR TITLE
docs: add number of subscribers test result to documentation

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -168,6 +168,7 @@ UDM
 UDP
 UDR
 UE
+UEs
 ueransim
 UERANSIM
 UERANSIM's

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -1,21 +1,29 @@
 # Performance
 
-## UPF throughput
+## Results
 
-### Results
+### UPF throughput
 
-| UE Type               | UPF Mode  | CNI Type    | Downlink   | Uplink     |
-| --------------------- | --------- | --------    | ---------  | ---------  |
-| UERANSIM              | DPDK      | vfioveth    | 962 Mbps   | 957 Mbps   |
-| UERANSIM              | AF_PACKET | bridge      | 7.8 Mbps   | 823.8 Mbps |
-| UERANSIM              | AF_PACKET | MACVLAN     | 8.27 Mbps  | 958 Mbps   |
-| UERANSIM              | AF_PACKET | host-device | 8 Mbps     | 957.2 Mbps |
-| Quectel RM520N-GL     | DPDK      | vfioveth    | 79.8 Mbps  | 12.5 Mbps  |
-| Quectel RM520N-GL     | AF_PACKET | bridge      | 0.741 Mbps | 11.7 Mbps  |
-| Quectel RM520N-GL     | AF_PACKET | MACVLAN     | 0.748 Mbps | 12.8 Mbps  |
-| Quectel RM520N-GL     | AF_PACKET | host-device | 0.739 Mbps | 12.46 Mbps |
+| UE Type           | UPF Mode  | CNI Type    | Downlink   | Uplink     |
+| ----------------- | --------- | ----------- | ---------- | ---------- |
+| UERANSIM          | DPDK      | vfioveth    | 962 Mbps   | 957 Mbps   |
+| UERANSIM          | AF_PACKET | bridge      | 7.8 Mbps   | 823.8 Mbps |
+| UERANSIM          | AF_PACKET | MACVLAN     | 8.27 Mbps  | 958 Mbps   |
+| UERANSIM          | AF_PACKET | host-device | 8 Mbps     | 957.2 Mbps |
+| Quectel RM520N-GL | DPDK      | vfioveth    | 79.8 Mbps  | 12.5 Mbps  |
+| Quectel RM520N-GL | AF_PACKET | bridge      | 0.741 Mbps | 11.7 Mbps  |
+| Quectel RM520N-GL | AF_PACKET | MACVLAN     | 0.748 Mbps | 12.8 Mbps  |
+| Quectel RM520N-GL | AF_PACKET | host-device | 0.739 Mbps | 12.46 Mbps |
 
-### Methodology
+### Subscribers
+
+Charmed Aether SD-Core can stand up **500 concurrent PDU sessions**, the maximum UERANSIM supports.
+
+Further testing would be needed to determine the maximum number of PDU sessions that can be supported by the Core.
+
+## Methodology
+
+### UPF throughput
 
 Tests were performed using `iperf3` to measure the throughput between the
 UE and an iPerf3 server going through the UPF.
@@ -64,3 +72,10 @@ with a bandwidth of 40 MHz. The radio unit used was a USRP B210 and the UE modul
 was a Quectel RM520N-GL over USB.
 
 This test is limited by the radio link configuration.
+
+### Subscribers
+
+The PDU sessions were tested using the UERANSIM simulator on the RAN host.
+
+We used the `--num-of-UE` flag to specify the number of UEs to simulate. We tested
+the maximum number of UEs that UERANSIM supports, which is 500.


### PR DESCRIPTION
# Description

Here we add test results for the number of subscribers as obtained through UERANSIM. UERANSIM supports up to 500 concurrent PDU sessions and we were able to go up to that limit. Further testing would be needed to validate what's the absolute limit of the core, but the fact that it's at least 500 is already useful information.

## Running UERANSIM for 500 UEs

Running ueransim for more than 1 UE is quite simple with the `-n` flag. It will incremente the imsi by 1 for each additional subscriber and use the same opc and key:

```shell
/usr/bin/nr-ue -c /etc/ueransim/ue.yaml -n 500
```

Here is the run output:
  - [ueransim_500.txt](https://github.com/user-attachments/files/18720747/ueransim_500.txt)

You can then use any of those PDU sessions to access the internet:

```shell
root@ueransim-k8s-0:/# ping -I uesimtun156 8.8.8.8 -c 4
PING 8.8.8.8 (8.8.8.8) from 172.250.6.242 uesimtun156: 56(84) bytes of data.
64 bytes from 8.8.8.8: icmp_seq=1 ttl=113 time=14.6 ms
64 bytes from 8.8.8.8: icmp_seq=2 ttl=113 time=24.3 ms
64 bytes from 8.8.8.8: icmp_seq=3 ttl=113 time=16.9 ms
64 bytes from 8.8.8.8: icmp_seq=4 ttl=113 time=33.8 ms

--- 8.8.8.8 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3005ms
rtt min/avg/max/mdev = 14.617/22.396/33.788/7.486 ms
root@ueransim-k8s-0:/# 
```

## Script for loading 500 subscribers in the Core

```python
import logging

from tests.integration.nms_helper import NMS

logger = logging.getLogger(__name__)


IMSI_0 = "001010100007487"
NUM_SUBSCRIBERS = 500
TEST_DEVICE_GROUP_NAME = "default-default"
TEST_NETWORK_SLICE_NAME = "default"
NMS_IP_ADDRESS = "1.2.3.4"
NMS_USERNAME = "my-username"
NMS_PASSWORD = "my-password"


nms_client = NMS(url=f"https://{NMS_IP_ADDRESS}:5000")
nms_client.wait_for_api_to_be_available()
nms_client.wait_for_initialized()
login_response = nms_client.login(username=NMS_USERNAME, password=NMS_PASSWORD)
if not login_response or not login_response.token:
    raise Exception("Failed to login to NMS.")

for i in range(NUM_SUBSCRIBERS):
    imsi = str(int(IMSI_0) + i).zfill(len(IMSI_0))
    nms_client.create_subscriber(imsi=imsi, token=login_response.token)

imsi_list = [str(int(IMSI_0) + i).zfill(len(IMSI_0)) for i in range(NUM_SUBSCRIBERS)]
nms_client.create_device_group(
    name=TEST_DEVICE_GROUP_NAME, imsis=imsi_list, token=login_response.token
)

nms_client.create_network_slice(
    name=TEST_NETWORK_SLICE_NAME,
    device_groups=[TEST_DEVICE_GROUP_NAME],
    token=login_response.token,
)
```
# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
