### PR TITLE
chore: replace domain from .mgmt to .mgmt.local

### DIFF
--- a/docs/how-to/test_upf_performance.md
+++ b/docs/how-to/test_upf_performance.md
@@ -55,7 +55,7 @@ above.
 
 Edit the `gtpIp` field to `10.204.0.100`.
 
-Edit the `address` field under `amfConfigs` to `amf.mgmt`.
+Edit the `address` field under `amfConfigs` to `amf.mgmt.local`.
 
 This section of the file should look like this:
 
@@ -66,7 +66,7 @@ gtpIp:  10.204.0.100 # IP to use to communicate with the UPF
 
 # List of AMF address information
 amfConfigs:
-  - address: amf.mgmt
+  - address: amf.mgmt.local
     port: 38412
 ```
 

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -670,7 +670,7 @@ module "sdcore-user-plane" {
     access-ip             = "10.202.0.10/24"
     core-gateway-ip       = "10.203.0.1"
     core-ip               = "10.203.0.10/24"
-    external-upf-hostname = "upf.mgmt"
+    external-upf-hostname = "upf.mgmt.local"
     access-interface-mac-address = "c2:c8:c7:e9:cc:18" # In this example, its the MAC address of access interface.
     core-interface-mac-address = "e2:01:8e:95:cb:4d" # In this example, its the MAC address of core interface
     enable-hw-checksum           = "false"
@@ -860,7 +860,7 @@ In the Network Management System (NMS), create a network slice with the followin
 - Name: `Tutorial`
 - MCC: `001`
 - MNC: `01`
-- UPF: `upf.mgmt:8805`
+- UPF: `upf.mgmt.local:8805`
 - gNodeB: `gnbsim-gnbsim-gnbsim (tac:1)`
 
 You should see the following network slice created.

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -128,7 +128,7 @@ Export the Kubernetes configuration and copy it to the `juju-controller` VM:
 
 ```console
 sudo microk8s.config > /tmp/control-plane-cluster.yaml
-scp /tmp/control-plane-cluster.yaml juju-controller.mgmt:
+scp /tmp/control-plane-cluster.yaml juju-controller.mgmt.local:
 ```
 
 Log out of the VM.
@@ -381,7 +381,7 @@ Export the Kubernetes configuration and copy it to the `juju-controller` VM:
 
 ```console
 sudo microk8s.config > /tmp/user-plane-cluster.yaml
-scp /tmp/user-plane-cluster.yaml juju-controller.mgmt:
+scp /tmp/user-plane-cluster.yaml juju-controller.mgmt.local:
 ```
 
 Log out of the VM.
@@ -412,7 +412,7 @@ Export the Kubernetes configuration and copy it to the `juju-controller` VM:
 
 ```console
 sudo microk8s.config > /tmp/gnb-cluster.yaml
-scp /tmp/gnb-cluster.yaml juju-controller.mgmt:
+scp /tmp/gnb-cluster.yaml juju-controller.mgmt.local:
 ```
 
 Create the MACVLAN bridges for `enp6s0`, and label them accordingly:
@@ -532,7 +532,7 @@ module "sdcore-control-plane" {
   model = data.juju_model.control-plane.name
 
   amf_config = {
-    external-amf-hostname = "amf.mgmt"
+    external-amf-hostname = "amf.mgmt.local"
   }
   traefik_config = {
     routing_mode = "subdomain"
@@ -592,7 +592,7 @@ We will need them shortly.
 ```{note}
 If the IP for the AMF is not `10.201.0.52`, you will need to update the DNS entry to match the actual external IP for the AMF. In the host, edit the `main.tf` file. Find the following line and set it to the correct IP address, like so:
 
-`host-record=amf.mgmt,10.201.0.53`
+`host-record=amf.mgmt.local,10.201.0.53`
 
 Then, run the following command on the host:
 
@@ -612,7 +612,7 @@ module "sdcore-control-plane" {
   (...)
   amf_config = {
     external-amf-ip       = "10.201.0.52"
-    external-amf-hostname = "amf.mgmt"
+    external-amf-hostname = "amf.mgmt.local"
   }
   (...)
 }

--- a/examples/terraform/mastering/main.tf
+++ b/examples/terraform/mastering/main.tf
@@ -9,7 +9,7 @@ module "sdcore-control-plane" {
 
   amf_config = {
     external-amf-ip       = "10.201.0.52"
-    external-amf-hostname = "amf.mgmt"
+    external-amf-hostname = "amf.mgmt.local"
   }
   traefik_config = {
     routing_mode      = "subdomain"

--- a/examples/terraform/mastering/main.tf
+++ b/examples/terraform/mastering/main.tf
@@ -34,7 +34,7 @@ module "sdcore-user-plane" {
     core-gateway-ip       = "10.203.0.1"
     core-interface        = "core"
     core-ip               = "10.203.0.10/24"
-    external-upf-hostname = "upf.mgmt"
+    external-upf-hostname = "upf.mgmt.local"
     gnb-subnet            = "10.204.0.0/24"
   }
 }
@@ -102,9 +102,9 @@ module "cos-lite" {
   model_name               = "cos-lite"
   deploy_cos_configuration = true
   cos_configuration_config = {
-    git_repo                 = "https://github.com/canonical/sdcore-cos-configuration"
-    git_branch               = "main"
-    grafana_dashboards_path  = "grafana_dashboards/sdcore/"
+    git_repo                = "https://github.com/canonical/sdcore-cos-configuration"
+    git_branch              = "main"
+    grafana_dashboards_path = "grafana_dashboards/sdcore/"
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     lxd = {
-      source = "terraform-lxd/lxd"
+      source  = "terraform-lxd/lxd"
       version = "2.4.0"
     }
   }
@@ -23,11 +23,11 @@ resource "lxd_network" "sdcore-mgmt" {
     "ipv4.address" = "10.201.0.1/24"
     "ipv4.nat"     = "true"
     "ipv6.address" = "none"
-    "dns.mode" = "managed"
-    "dns.domain" = "mgmt"
-    "raw.dnsmasq" = <<-EOF
+    "dns.mode"     = "managed"
+    "dns.domain"   = "mgmt"
+    "raw.dnsmasq"  = <<-EOF
         host-record=amf.mgmt,10.201.0.52
-        host-record=upf.mgmt,10.201.0.200
+        host-record=upf.mgmt.local,10.201.0.200
     EOF
   }
 }
@@ -40,7 +40,7 @@ resource "lxd_network" "sdcore-access" {
     "ipv4.address" = "10.202.0.1/24"
     "ipv4.nat"     = "false"
     "ipv6.address" = "none"
-    "dns.mode" = "none"
+    "dns.mode"     = "none"
   }
 }
 
@@ -52,7 +52,7 @@ resource "lxd_network" "sdcore-core" {
     "ipv4.address" = "10.203.0.1/24"
     "ipv4.nat"     = "true"
     "ipv6.address" = "none"
-    "dns.mode" = "none"
+    "dns.mode"     = "none"
   }
 }
 
@@ -64,7 +64,7 @@ resource "lxd_network" "sdcore-ran" {
     "ipv4.address" = "10.204.0.1/24"
     "ipv4.nat"     = "false"
     "ipv6.address" = "none"
-    "dns.mode" = "none"
+    "dns.mode"     = "none"
   }
 }
 
@@ -76,14 +76,14 @@ resource "tls_private_key" "juju-key" {
 resource "lxd_instance" "control-plane" {
   name  = "control-plane"
   image = "ubuntu:24.04"
-  type = "virtual-machine"
+  type  = "virtual-machine"
 
   config = {
     "boot.autostart" = true
   }
 
   limits = {
-    cpu = 4
+    cpu    = 4
     memory = "8GB"
   }
 
@@ -103,7 +103,7 @@ resource "lxd_instance" "control-plane" {
     name = "eth0"
 
     properties = {
-      network = "sdcore-mgmt"
+      network        = "sdcore-mgmt"
       "ipv4.address" = "10.201.0.101"
     }
   }
@@ -115,12 +115,12 @@ resource "lxd_instance" "control-plane" {
 }
 
 resource "lxd_instance_file" "control-plane-pubkey" {
-  instance = lxd_instance.control-plane.name
-  content = tls_private_key.juju-key.public_key_openssh
+  instance    = lxd_instance.control-plane.name
+  content     = tls_private_key.juju-key.public_key_openssh
   target_path = "/home/ubuntu/.ssh/authorized_keys"
-  uid = 1000
-  gid = 1000
-  mode = "0600"
+  uid         = 1000
+  gid         = 1000
+  mode        = "0600"
 
   depends_on = [
     lxd_instance.control-plane
@@ -128,12 +128,12 @@ resource "lxd_instance_file" "control-plane-pubkey" {
 }
 
 resource "lxd_instance_file" "control-plane-privkey" {
-  instance = lxd_instance.control-plane.name
-  content = tls_private_key.juju-key.private_key_openssh
+  instance    = lxd_instance.control-plane.name
+  content     = tls_private_key.juju-key.private_key_openssh
   target_path = "/home/ubuntu/.ssh/id_rsa"
-  uid = 1000
-  gid = 1000
-  mode = "0600"
+  uid         = 1000
+  gid         = 1000
+  mode        = "0600"
 
   depends_on = [
     lxd_instance.control-plane
@@ -143,14 +143,14 @@ resource "lxd_instance_file" "control-plane-privkey" {
 resource "lxd_instance" "juju-controller" {
   name  = "juju-controller"
   image = "ubuntu:24.04"
-  type = "virtual-machine"
+  type  = "virtual-machine"
 
   config = {
     "boot.autostart" = true
   }
 
   limits = {
-    cpu = 4
+    cpu    = 4
     memory = "6GB"
   }
 
@@ -170,7 +170,7 @@ resource "lxd_instance" "juju-controller" {
     name = "eth0"
 
     properties = {
-      network = "sdcore-mgmt"
+      network        = "sdcore-mgmt"
       "ipv4.address" = "10.201.0.104"
     }
   }
@@ -182,12 +182,12 @@ resource "lxd_instance" "juju-controller" {
 }
 
 resource "lxd_instance_file" "juju-controller-pubkey" {
-  instance = lxd_instance.juju-controller.name
-  content = tls_private_key.juju-key.public_key_openssh
+  instance    = lxd_instance.juju-controller.name
+  content     = tls_private_key.juju-key.public_key_openssh
   target_path = "/home/ubuntu/.ssh/authorized_keys"
-  uid = 1000
-  gid = 1000
-  mode = "0600"
+  uid         = 1000
+  gid         = 1000
+  mode        = "0600"
 
   depends_on = [
     lxd_instance.juju-controller
@@ -195,12 +195,12 @@ resource "lxd_instance_file" "juju-controller-pubkey" {
 }
 
 resource "lxd_instance_file" "juju-controller-privkey" {
-  instance = lxd_instance.juju-controller.name
-  content = tls_private_key.juju-key.private_key_openssh
+  instance    = lxd_instance.juju-controller.name
+  content     = tls_private_key.juju-key.private_key_openssh
   target_path = "/home/ubuntu/.ssh/id_rsa"
-  uid = 1000
-  gid = 1000
-  mode = "0600"
+  uid         = 1000
+  gid         = 1000
+  mode        = "0600"
 
   depends_on = [
     lxd_instance.juju-controller
@@ -210,15 +210,15 @@ resource "lxd_instance_file" "juju-controller-privkey" {
 resource "lxd_instance" "gnbsim" {
   name  = "gnbsim"
   image = "ubuntu:24.04"
-  type = "virtual-machine"
+  type  = "virtual-machine"
 
   config = {
-    "boot.autostart" = true
+    "boot.autostart"            = true
     "cloud-init.network-config" = file("gnbsim-network-config.yml")
   }
 
   limits = {
-    cpu = 2
+    cpu    = 2
     memory = "3GB"
   }
 
@@ -238,7 +238,7 @@ resource "lxd_instance" "gnbsim" {
     name = "eth0"
 
     properties = {
-      network = "sdcore-mgmt"
+      network        = "sdcore-mgmt"
       "ipv4.address" = "10.201.0.103"
     }
   }
@@ -248,7 +248,7 @@ resource "lxd_instance" "gnbsim" {
     name = "eth1"
 
     properties = {
-      network = "sdcore-ran"
+      network        = "sdcore-ran"
       "ipv4.address" = "10.204.0.100"
     }
   }
@@ -261,12 +261,12 @@ resource "lxd_instance" "gnbsim" {
 }
 
 resource "lxd_instance_file" "gnbsim-pubkey" {
-  instance = lxd_instance.gnbsim.name
-  content = tls_private_key.juju-key.public_key_openssh
+  instance    = lxd_instance.gnbsim.name
+  content     = tls_private_key.juju-key.public_key_openssh
   target_path = "/home/ubuntu/.ssh/authorized_keys"
-  uid = 1000
-  gid = 1000
-  mode = "0600"
+  uid         = 1000
+  gid         = 1000
+  mode        = "0600"
 
   depends_on = [
     lxd_instance.gnbsim
@@ -274,12 +274,12 @@ resource "lxd_instance_file" "gnbsim-pubkey" {
 }
 
 resource "lxd_instance_file" "gnbsim-privkey" {
-  instance = lxd_instance.gnbsim.name
-  content = tls_private_key.juju-key.private_key_openssh
+  instance    = lxd_instance.gnbsim.name
+  content     = tls_private_key.juju-key.private_key_openssh
   target_path = "/home/ubuntu/.ssh/id_rsa"
-  uid = 1000
-  gid = 1000
-  mode = "0600"
+  uid         = 1000
+  gid         = 1000
+  mode        = "0600"
 
   depends_on = [
     lxd_instance.gnbsim
@@ -289,15 +289,15 @@ resource "lxd_instance_file" "gnbsim-privkey" {
 resource "lxd_instance" "user-plane" {
   name  = "user-plane"
   image = "ubuntu:24.04"
-  type = "virtual-machine"
+  type  = "virtual-machine"
 
   config = {
-    "boot.autostart" = true
+    "boot.autostart"            = true
     "cloud-init.network-config" = file("user-plane-network-config.yml")
   }
 
   limits = {
-    cpu = 4
+    cpu    = 4
     memory = "12GB"
   }
 
@@ -317,7 +317,7 @@ resource "lxd_instance" "user-plane" {
     name = "eth0"
 
     properties = {
-      network = "sdcore-mgmt"
+      network        = "sdcore-mgmt"
       "ipv4.address" = "10.201.0.102"
     }
   }
@@ -327,7 +327,7 @@ resource "lxd_instance" "user-plane" {
     name = "eth1"
 
     properties = {
-      network = "sdcore-core"
+      network        = "sdcore-core"
       "ipv4.address" = "10.203.0.100"
     }
   }
@@ -337,7 +337,7 @@ resource "lxd_instance" "user-plane" {
     name = "eth2"
 
     properties = {
-      network = "sdcore-access"
+      network        = "sdcore-access"
       "ipv4.address" = "10.202.0.100"
       #"ipv4.routes" = "10.204.0.0/24"
     }
@@ -352,12 +352,12 @@ resource "lxd_instance" "user-plane" {
 }
 
 resource "lxd_instance_file" "user-plane-pubkey" {
-  instance = lxd_instance.user-plane.name
-  content = tls_private_key.juju-key.public_key_openssh
+  instance    = lxd_instance.user-plane.name
+  content     = tls_private_key.juju-key.public_key_openssh
   target_path = "/home/ubuntu/.ssh/authorized_keys"
-  uid = 1000
-  gid = 1000
-  mode = "0600"
+  uid         = 1000
+  gid         = 1000
+  mode        = "0600"
 
   depends_on = [
     lxd_instance.user-plane
@@ -365,12 +365,12 @@ resource "lxd_instance_file" "user-plane-pubkey" {
 }
 
 resource "lxd_instance_file" "user-plane-privkey" {
-  instance = lxd_instance.user-plane.name
-  content = tls_private_key.juju-key.private_key_openssh
+  instance    = lxd_instance.user-plane.name
+  content     = tls_private_key.juju-key.private_key_openssh
   target_path = "/home/ubuntu/.ssh/id_rsa"
-  uid = 1000
-  gid = 1000
-  mode = "0600"
+  uid         = 1000
+  gid         = 1000
+  mode        = "0600"
 
   depends_on = [
     lxd_instance.user-plane

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,9 +24,9 @@ resource "lxd_network" "sdcore-mgmt" {
     "ipv4.nat"     = "true"
     "ipv6.address" = "none"
     "dns.mode"     = "managed"
-    "dns.domain"   = "mgmt"
+    "dns.domain"   = "mgmt.local"
     "raw.dnsmasq"  = <<-EOF
-        host-record=amf.mgmt,10.201.0.52
+        host-record=amf.mgmt.local,10.201.0.52
         host-record=upf.mgmt.local,10.201.0.200
     EOF
   }


### PR DESCRIPTION
# Description

Here, we replace `.mgmt` with `.mgmt.local`. This change is required because of a recent change in the webconsole where we do input validation on the upf hostname and `.mgmt` is not a valid domain.

This PR partly addresses the issue identified here:
- https://github.com/canonical/sdcore-nms-k8s-operator/issues/441

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
