### PR TITLE
chore: bump to latest workload versions

### DIFF
--- a/docs/reference/components.md
+++ b/docs/reference/components.md
@@ -9,15 +9,15 @@ Charmed Aether SD-Core `v1.6` is composed of the following components and their 
 | {bdg-link-primary-line}`Self Signed Certificates  <https://charmhub.io/self-signed-certificates>` | 1/stable           | N/A                  |
 | {bdg-link-primary-line}`Traefik  <https://charmhub.io/self-signed-certificates>`                  | latest/stable      | 2                    |
 | {bdg-link-primary-line}`AMF  <https://charmhub.io/sdcore-amf-k8s>`                                | 1.6/edge           | 1.6                  |
-| {bdg-link-primary-line}`AUSF  <https://charmhub.io/sdcore-ausf-k8s>`                              | 1.6/edge           | 1.5                  |
+| {bdg-link-primary-line}`AUSF  <https://charmhub.io/sdcore-ausf-k8s>`                              | 1.6/edge           | 1.6                  |
 | {bdg-link-primary-line}`GNBSIM  <https://charmhub.io/sdcore-gnbsim-k8s>`                          | 1.6/edge           | 1.6                  |
 | {bdg-link-primary-line}`NMS  <https://charmhub.io/sdcore-nms-k8s>`                                | 1.6/edge           | 1.1                  |
 | {bdg-link-primary-line}`NRF  <https://charmhub.io/sdcore-nrf-k8s>`                                | 1.6/edge           | 1.6                  |
-| {bdg-link-primary-line}`NSSF  <https://charmhub.io/sdcore-nssf-k8s>`                              | 1.6/edge           | 1.5                  |
-| {bdg-link-primary-line}`PCF  <https://charmhub.io/sdcore-pcf-k8s>`                                | 1.6/edge           | 1.5                  |
+| {bdg-link-primary-line}`NSSF  <https://charmhub.io/sdcore-nssf-k8s>`                              | 1.6/edge           | 1.6                  |
+| {bdg-link-primary-line}`PCF  <https://charmhub.io/sdcore-pcf-k8s>`                                | 1.6/edge           | 1.6                  |
 | {bdg-link-primary-line}`Router  <https://charmhub.io/sdcore-router-k8s>`                          | 1.6/edge           | 0.1                  |
 | {bdg-link-primary-line}`SMF  <https://charmhub.io/sdcore-smf-k8s>`                                | 1.6/edge           | 2.0                  |
-| {bdg-link-primary-line}`UDM  <https://charmhub.io/sdcore-udm-k8s>`                                | 1.6/edge           | 1.5                  |
+| {bdg-link-primary-line}`UDM  <https://charmhub.io/sdcore-udm-k8s>`                                | 1.6/edge           | 1.6                  |
 | {bdg-link-primary-line}`UDR  <https://charmhub.io/sdcore-udr-k8s>`                                | 1.6/edge           | 1.6                  |
 | {bdg-link-primary-line}`UPF  <https://charmhub.io/sdcore-upf-k8s>`                                | 1.6/edge           | 2.0                  |
 


### PR DESCRIPTION
# Description

We update the component documentation as we updated the minor version of some charm workloads. This PR depends on the following PR's being merged first:
- https://github.com/canonical/sdcore-ausf-k8s-operator/pull/410
- https://github.com/canonical/sdcore-nssf-k8s-operator/pull/407
- https://github.com/canonical/sdcore-pcf-k8s-operator/pull/414
- https://github.com/canonical/sdcore-udm-k8s-operator/pull/397

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
