### PR TITLE
fix:  add subscriber set up before simulation in getting started tutorial

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -398,7 +398,7 @@ After clicking on the `Submit` button you should see the subscriber created:
 
 ## 8. Run the 5G simulation
 
-Switch to the `ran` model and set up the subscriber information using the value noted in the previous step:
+Switch to the `ran` model and set up the subscriber information using the values noted in the previous step:
 
 ```console
 juju switch ran

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -398,7 +398,14 @@ After clicking on the `Submit` button you should see the subscriber created:
 
 ## 8. Run the 5G simulation
 
-Switch to the `ran` model and make sure that the `gnbsim` application is in `Active/Idle` state.
+Switch to the `ran` model and set up the subscriber information using the value noted in the previous step:
+
+```console
+juju switch ran
+juju config gnbsim imsi=<IMSI> usim-opc=<OPC> usim-key=<Key> usim-sequence-number=<Sequence Number>
+```
+
+Make sure that the `gnbsim` application is in `Active/Idle` state.
 
 ```console
 juju switch ran
@@ -423,12 +430,6 @@ gnbsim  1.4.5    active      1  sdcore-gnbsim-k8s  1.6/edge  638  10.152.183.85 
 
 Unit       Workload  Agent  Address       Ports  Message
 gnbsim/0*  active    idle   10.1.194.239
-```
-
-Set up the subscriber information using the value noted in the previous step:
-
-```
-juju config gnbsim imsi=<IMSI> usim-opc=<OPC> usim-key=<Key> usim-sequence-number=<Sequence Number>
 ```
 
 Run the simulation:

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -408,7 +408,6 @@ juju config gnbsim imsi=<IMSI> usim-opc=<OPC> usim-key=<Key> usim-sequence-numbe
 Make sure that the `gnbsim` application is in `Active/Idle` state.
 
 ```console
-juju switch ran
 juju status
 ```
 

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -387,7 +387,9 @@ Navigate to Subscribers and click on Create. Fill in the following:
 - Network Slice: `default`
 - Device Group: `device-group`
 
-Click on the two `Generate` buttons to automatically fill in the IMSI, OPC, Key and Sequence Number. After clicking on the `Submit` button you should see the subscriber created:
+Click on the two `Generate` buttons to automatically fill in the values in the form. Note the IMSI, OPC, Key and Sequence Number, we are going to use them in the next step.
+
+After clicking on the `Submit` button you should see the subscriber created:
 
 ```{image} ../images/getting_started_subscriber.png
 :alt: NMS Subscriber
@@ -421,6 +423,12 @@ gnbsim  1.4.5    active      1  sdcore-gnbsim-k8s  1.6/edge  638  10.152.183.85 
 
 Unit       Workload  Agent  Address       Ports  Message
 gnbsim/0*  active    idle   10.1.194.239
+```
+
+Set up the subscriber information using the value noted in the previous step:
+
+```
+juju config gnbsim imsi=<IMSI> usim-opc=<OPC> usim-key=<Key> usim-sequence-number=<Sequence Number>
 ```
 
 Run the simulation:


### PR DESCRIPTION
# Description

When we are not using the gnbsim default values for the subscriber, we need to set the imsi, opc, key and sequence number in the gnbsim config

This PR adds this steps to the getting started tutorial

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
