### PR TITLE
feat: expand security documentation

### DIFF
--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -213,5 +213,6 @@ VM
 VMs
 VM's
 VPN
+VPNs
 Webui
 yaml

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -92,6 +92,7 @@ iPerf
 jq
 juju
 Juju
+JWT
 kB
 K8s
 Ki

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -2,6 +2,7 @@ accessDstMAC
 addon
 addons
 Aether
+Alertmanager
 AKS
 allocatable
 AMF
@@ -34,6 +35,7 @@ coreDstMAC
 Corefile
 CPUs
 CSR
+customizable
 DDR
 deployable
 deregister
@@ -49,6 +51,7 @@ DNS
 driverctl
 enp
 EKS
+ETCD
 frictionless
 gb
 GCP
@@ -71,6 +74,7 @@ Haswell
 healthcheck
 hostname
 http
+HTTPS
 hugepages
 HugePages
 init
@@ -109,6 +113,7 @@ MicroK
 Microk8s
 microservices
 Milenage
+MITM
 MNC
 Mongo
 MSIN
@@ -123,6 +128,7 @@ netplan
 newgrp
 Nameserver
 nameservers
+NFs
 NIC
 NGAPP
 nms
@@ -149,6 +155,8 @@ PDU
 PFCP
 Pre
 prometheus
+PSP
+PSS
 QI
 QoS
 Quectel
@@ -158,6 +166,7 @@ requirer
 RDRAND
 Rockcraft
 Ryzen
+sanitization
 SCTP
 sdcore
 sdcore-k8s
@@ -173,6 +182,7 @@ TCP
 tcp
 Terraform
 Terraform's
+TTL
 TLS
 Traefik
 Traefik's
@@ -199,5 +209,6 @@ VLAN
 VM
 VMs
 VM's
+VPN
 Webui
 yaml

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -125,6 +125,7 @@ N3
 N4
 N6
 namespace
+namespaces
 netplan
 newgrp
 Nameserver

--- a/docs/.wordlist.txt
+++ b/docs/.wordlist.txt
@@ -75,6 +75,7 @@ healthcheck
 hostname
 http
 HTTPS
+hostPath
 hugepages
 HugePages
 init

--- a/docs/explanation/hardening.md
+++ b/docs/explanation/hardening.md
@@ -37,11 +37,7 @@ To enhance the security of the deployment infrastructure, firewalls can be confi
 
 ### Enforce Pod Security
 
-Kubernetes offers Pod Security Standards (PSS) as a replacement for the deprecated Pod Security Policies (PSP). MicroK8s uses the built-in Pod Security Admission controller to enforce these standards.
-
-1. Set Namespace-Level Pod Security Standards (PSS):
-
-There are three pod security admission profile levels:
+Kubernetes offers Pod Security Standards (PSS) as a replacement for the deprecated Pod Security Policies (PSP). MicroK8s uses the built-in Pod Security Admission controller to enforce these standards. There are three pod security admission profile levels:
 
 **Privileged** allows pods to run with elevated privileges and fewer security restrictions. It is needed for workloads that require extensive host access such as debugging tools, administrative pods.
 
@@ -65,5 +61,5 @@ Loki centralizes log data, allowing operators to correlate logs from multiple 5G
 
 All of these observability features are accessible through Grafana, which provides customizable dashboards with actionable insights into the real-time health of the system. By integrating COS with Charmed Aether SD-Core, operators can establish a secure and resilient operational environment, proactively address issues and ensure uninterrupted connectivity for end-users. 
 
-Please follow [this guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/v1.5/how-to/integrate_sdcore_with_observability/) to integrate with Cos stack.
+Please follow [this guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/v1.5/how-to/integrate_sdcore_with_observability/) to integrate with COS stack.
 

--- a/docs/explanation/hardening.md
+++ b/docs/explanation/hardening.md
@@ -1,33 +1,32 @@
 # Hardening
 
+This section explains how to harden Charmed Aether SD-Core by securing infrastructure with firewalls, VPNs, traffic restrictions and IP whitelisting, while enhancing operations through monitoring and alerting with the Canonical Observability Stack (COS).
+
 ## Infrastructure Hardening
 
-1. Deploy the Charmed Aether SD-Core behind a firewall:
-   - Allow only inbound traffic to required ports for the 5G Core.
-   - Enable only outgoing traffic necessary for communication with trusted endpoints like RAN and DN.
+1. Deploy Charmed Aether SD-Core behind a firewall:
 
-2. Restrict protocols to 5G Core essentials:
-   a. Allow:
-      - SCTP: For N2 interface communication (AMF).
-      - UDP: For PFCP (SMF <-> UPF) and GTP-U (UPF <-> RAN).
-      - TCP: For HTTP/HTTPS services like NRF or API communication.
-      - DNS/TLS: For discovery and secure communication.
+   a. Allow only inbound traffic to required ports for the 5G Core.
 
-   b. Block other protocols including ICMP, FTP, Telnet, or legacy application protocols unless absolutely necessary.
+         - 2152 (UDP) for UPF (GTP-U traffic)
+         - 38412 (SCTP) for AMF (NGAP from gNBs)
+         - 443 (HTTPS) for NMS (management access)
 
-3. Protect public endpoints and management systems:
-   - Use IP whitelisting to allow only trusted IP ranges.
-   - Place the Charmed Aether SD-Core network behind a VPN or private network for additional security.
+   b. Enable only outgoing traffic necessary for communication with trusted endpoints like RAN and DN.
 
-## Hardening Containerized Applications
+   c. Restrict protocols to 5G Core essentials:
 
-1. Enforce Pod Security:
-   - Use the Kubernetes Pod Security Admission controller.
-   - Apply the `restricted` profile to namespaces with the following command:
+        i. Allow:
+            - SCTP: For N2 interface communication (AMF).
+            - UDP: For PFCP (SMF <-> UPF) and GTP-U (UPF <-> RAN).
+            - TCP: For HTTP/HTTPS services like NRF or API communication.
+            - DNS/TLS: For discovery and secure communication.
 
-```bash
-kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=restricted
-```
+        ii. Block other protocols including ICMP, FTP, Telnet, or legacy application protocols unless absolutely necessary.
+   
+   d. Use IP whitelisting to allow only trusted IP ranges.
+
+2. Place Charmed Aether SD-Core network behind a VPN or private network for additional security.
 
 ## Operational Hardening
 

--- a/docs/explanation/hardening.md
+++ b/docs/explanation/hardening.md
@@ -61,5 +61,5 @@ Loki centralizes log data, allowing operators to correlate logs from multiple 5G
 
 All of these observability features are accessible through Grafana, which provides customizable dashboards with actionable insights into the real-time health of the system. By integrating COS with Charmed Aether SD-Core, operators can establish a secure and resilient operational environment, proactively address issues and ensure uninterrupted connectivity for end-users. 
 
-Please follow [this guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/v1.5/how-to/integrate_sdcore_with_observability/) to integrate with COS stack.
+Please follow [this guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/v1.5/how-to/integrate_sdcore_with_observability) to integrate with COS stack.
 

--- a/docs/explanation/hardening.md
+++ b/docs/explanation/hardening.md
@@ -2,30 +2,28 @@
 
 ## Infrastructure Hardening
 
-### Firewall Rules
+1. Deploy the Charmed Aether SD-Core behind a firewall:
+   - Allow only inbound traffic to required ports for the 5G Core.
+   - Enable only outgoing traffic necessary for communication with trusted endpoints like RAN and DN.
 
-Enforcing the firewall rules minimizes the attack surface while preserving the functionality required for operations. To enhance the security of the deployment infrastructure, firewalls can be configured with the following rules:
+2. Restrict protocols to 5G Core essentials:
+   a. Allow:
+      - SCTP: For N2 interface communication (AMF).
+      - UDP: For PFCP (SMF <-> UPF) and GTP-U (UPF <-> RAN).
+      - TCP: For HTTP/HTTPS services like NRF or API communication.
+      - DNS/TLS: For discovery and secure communication.
 
-1. Allow only inbound traffic targeting the required ports for the 5G Core and the outgoing traffic required for communication with trusted endpoints such as RAN and DN.
-2. Allow only essential protocols based on the 5G Core as follows:
-    - SCTP: For N2 interface communication (used by AMF).
-    - UDP: For PFCP (SMF <-> UPF) or GTP-U (UPF <-> RAN).
-    - TCP: For HTTP/HTTPS services like NRF or API communications.
-    - DNS/TLS: For Core service discovery and communication.
+   b. Block other protocols including ICMP, FTP, Telnet, or legacy application protocols unless absolutely necessary.
 
-   All other protocols like ICMP, FTP, Telnet, or legacy application protocols should be dropped unless explicitly needed.
-
-3. Protect public endpoints and Network Management System (NMS):
-    - Restrict access using IP whitelisting to allow only trusted IP ranges.
-    - Optionally, deploy the core system behind a VPN or private network to enhance security for management systems.
+3. Protect public endpoints and management systems:
+   - Use IP whitelisting to allow only trusted IP ranges.
+   - Place the Charmed Aether SD-Core network behind a VPN or private network for additional security.
 
 ## Hardening Containerized Applications
 
-### Enforce Pod Security
-
-To align with Kubernetes security best practices, MicroK8s leverages the Pod Security Admission controller. When setting up namespaces, we recommend applying the `restricted` profile, which enforces the highest security standards required for production workloads.
-
-To apply the `restricted` profile at the namespace level, use the following command:
+1. Enforce Pod Security:
+   - Use the Kubernetes Pod Security Admission controller.
+   - Apply the `restricted` profile to namespaces with the following command:
 
 ```bash
 kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=restricted
@@ -33,8 +31,7 @@ kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=restricte
 
 ## Operational Hardening
 
-### Monitoring and Alerts
-
-Monitoring and alerting are essential for maintaining the secure and reliable operation of Charmed Aether SD-Core. By integrating COS with Charmed Aether SD-Core, operators can proactively address issues, maintain system resilience and ensure uninterrupted connectivity for end-users. For detailed steps, please follow [this guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/latest/how-to/integrate_sdcore_with_observability).
-
+1. Integrate with the Canonical Observability Stack:
+   - Set up monitoring and alerts by integrating with the Canonical Observability Stack (COS).
+   - Refer to the [integration guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/latest/how-to/integrate_sdcore_with_observability) for steps.
 

--- a/docs/explanation/hardening.md
+++ b/docs/explanation/hardening.md
@@ -1,6 +1,6 @@
 # Hardening
 
-## Infrastructure and Network Hardening
+## Infrastructure Hardening
 
 ### Operating System Security
 
@@ -8,7 +8,7 @@ To ensure the security of operating systems in the deployment infrastructure (wh
 
 1. Automate OS security patches.
     - Enable automatic security updates to protect against newly discovered vulnerabilities.
-    - Tools for automatic updates such as `unattended-upgrades`.
+    - Use the tools for automatic updates such as `unattended-upgrades`.
     
 2. Enable Secure Boot to ensure that the system boots only trusted software, protecting against unauthorized code during startup.
 
@@ -44,23 +44,23 @@ MicroK8s uses the built-in Pod Security Admission controller to enforce these st
 
 There are three pod security admission profile levels:
 
-privileged:
+Privileged:
 - allowing pods to run with elevated privileges and fewer security restrictions.
 - needed for workloads that require extensive host access such as debugging tools, administrative pods.
 
-baseline:
+Baseline:
    - moderately restrictive profile targeting standard application workloads with very basic security constraints.
    - Cannot run as root by default.
    - Disallows hostPath volumes (which allow Pods to access the host's file system).
    - Prevents the use of certain Linux capabilities or privileged container execution.
 
-restricted:
+Restricted:
   - most restrictive profile ensuring compliance with high-security requirements.
   - requires all containers to drop all unnecessary Linux capabilities.
   - Disallows privileged containers and running as root.
   - Does not allow access to the underlying host's file system or network.
 
-Set `privileged` profile at the namespace level:
+Set `restricted` profile at the namespace level:
 
 ```bash
 kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=restricted
@@ -70,17 +70,11 @@ kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=restricte
 
 ### Monitoring and Alerts
 
-Monitoring and alerting are crucial for ensuring the secure and reliable operation of a 5G Core integrated with the Canonical Observability Stack (COS).
+Monitoring and alerting are crucial for ensuring the secure and reliable operation of a 5G Core integrated with the Canonical Observability Stack (COS). The COS Stack offers a comprehensive set of observability tools such as Prometheus, Loki, Alertmanager, and Grafana to continuously monitor system performance, detect anomalies, and respond to potential security or operational issues.
 
-The COS Stack offers a comprehensive set of observability tools such as Prometheus, Loki, Alertmanager, and Grafana to continuously monitor system performance, detect anomalies, and respond to potential security or operational issues.
+Loki centralizes log data, allowing operators to correlate logs from multiple 5G Core services to quickly identify the root cause of errors, unusual activity, or potential security breaches. Notifications for critical incidents, such as resource exhaustion, node failures or service disruptions are managed and delivered through Alertmanager which is part of Prometheus. 
 
-Loki centralizes log data, allowing operators to correlate logs from multiple 5G Core services to quickly identify the root cause of errors, unusual activity, or potential security breaches.
-
-Notifications for critical incidents, such as resource exhaustion, node failures or service disruptions are managed and delivered through Alertmanager which is part of Prometheus. 
-
-All of these observability features are accessible through Grafana, which provides customizable dashboards with actionable insights into the real-time health of the system.
-
-By integrating COS with Charmed Aether SD-Core, operators can establish a secure and resilient operational environment, proactively address issues and ensure uninterrupted connectivity for end-users. 
+All of these observability features are accessible through Grafana, which provides customizable dashboards with actionable insights into the real-time health of the system. By integrating COS with Charmed Aether SD-Core, operators can establish a secure and resilient operational environment, proactively address issues and ensure uninterrupted connectivity for end-users. 
 
 Please follow [this guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/v1.5/how-to/integrate_sdcore_with_observability/) to integrate with Cos stack.
 

--- a/docs/explanation/hardening.md
+++ b/docs/explanation/hardening.md
@@ -37,28 +37,17 @@ To enhance the security of the deployment infrastructure, firewalls can be confi
 
 ### Enforce Pod Security
 
-Kubernetes offers Pod Security Standards (PSS) as a replacement for the deprecated Pod Security Policies (PSP). 
-MicroK8s uses the built-in Pod Security Admission controller to enforce these standards.
+Kubernetes offers Pod Security Standards (PSS) as a replacement for the deprecated Pod Security Policies (PSP). MicroK8s uses the built-in Pod Security Admission controller to enforce these standards.
 
 1. Set Namespace-Level Pod Security Standards (PSS):
 
 There are three pod security admission profile levels:
 
-Privileged:
-- allowing pods to run with elevated privileges and fewer security restrictions.
-- needed for workloads that require extensive host access such as debugging tools, administrative pods.
+**Privileged** allows pods to run with elevated privileges and fewer security restrictions. It is needed for workloads that require extensive host access such as debugging tools, administrative pods.
 
-Baseline:
-   - moderately restrictive profile targeting standard application workloads with very basic security constraints.
-   - Cannot run as root by default.
-   - Disallows hostPath volumes (which allow Pods to access the host's file system).
-   - Prevents the use of certain Linux capabilities or privileged container execution.
+**Baseline** is moderately restrictive profile targeting standard application workloads with very basic security constraints. It cannot run as root by default and disallows hostPath volumes (which allow Pods to access the host's file system). Besides, it prevents the use of certain Linux capabilities or privileged container execution.
 
-Restricted:
-  - most restrictive profile ensuring compliance with high-security requirements.
-  - requires all containers to drop all unnecessary Linux capabilities.
-  - Disallows privileged containers and running as root.
-  - Does not allow access to the underlying host's file system or network.
+**Restricted** is the most restrictive profile ensuring compliance with high-security requirements. It requires all containers to drop all unnecessary Linux capabilities, disallows privileged containers and running as root. It also does not allow access to the underlying host's file system or network.
 
 Set `restricted` profile at the namespace level:
 

--- a/docs/explanation/hardening.md
+++ b/docs/explanation/hardening.md
@@ -4,56 +4,66 @@
 
 ### Operating System Security
 
-To ensure the security of operating systems in the deployment infrastructure (whether Virtual Machines or bare-metal servers), apply the following steps:
+To ensure the security of operating systems in the deployment infrastructure (whether virtual machines or bare-metal servers), apply the following steps:
 
-1. Automate OS security patches:
+1. Automate OS security patches.
     - Enable automatic security updates to protect against newly discovered vulnerabilities.
     - Tools for automatic updates such as `unattended-upgrades`.
     
-2. Enable Secure Boot to ensure the system boots only trusted software, protecting against unauthorized code during startup.
+2. Enable Secure Boot to ensure that the system boots only trusted software, protecting against unauthorized code during startup.
 
-3. Disable Unused Modules and Network Services. Identify and disable OS kernel modules and network services that are not required for application functionality, reducing the system’s attack surface.
+3. Disable unused modules and network services. Identify and disable OS kernel modules and network services that are not required for application functionality, reducing the system’s attack surface.
 
 ### Firewall Rules
 
 Enforcing the firewall rules minimizes the attack surface while preserving the functionality required for operations.
 
-To enhance the security of the deployment infrastructure, firewalls are configured with the following rules:
+To enhance the security of the deployment infrastructure, firewalls can be configured with the following rules:
 
-2. Allow only inbound traffic targeting the required ports for the 5G Core and the outgoing traffic required for communication with trusted endpoints.
-3. Allow Only Essential Protocols based on the 5G Core. Those are the required protocols:
+1. Allow only inbound traffic targeting the required ports for the 5G Core and the outgoing traffic required for communication with trusted endpoints such as RAN and DN.
+2. Allow only essential protocols based on the 5G Core as follows:
     - SCTP: For N2 interface communication (used by AMF).
     - UDP: For PFCP (SMF <-> UPF) or GTP-U (UPF <-> RAN).
     - TCP: For HTTP/HTTPS services like NRF or API communications.
     - DNS/TLS: For Core service discovery and communication.
 
-All other protocols like FTP, Telnet, or legacy application protocols should be dropped unless explicitly needed.
+   All other protocols like ICMP, FTP, Telnet, or legacy application protocols should be dropped unless explicitly needed.
 
-2. Protect Public Endpoints and Network Management System:
+3. Protect public endpoints and Network Management System (NMS):
     - Restrict access using IP whitelisting to allow only trusted IP ranges.
     - Optionally, implement a VPN or private network to access management systems for additional security.
 
 ## Hardening Containerized Applications
 
 ### Enforce Pod Security
+
 Kubernetes offers Pod Security Standards (PSS) as a replacement for the deprecated Pod Security Policies (PSP). 
 MicroK8s uses the built-in Pod Security Admission controller to enforce these standards.
+
 1. Set Namespace-Level Pod Security Standards (PSS):
 
-Apply `restricted`, `baseline`, or `privileged` profiles at the namespace level:
+There are three pod security admission profile levels:
+
+privileged:
+- allowing pods to run with elevated privileges and fewer security restrictions.
+- needed for workloads that require extensive host access such as debugging tools, administrative pods.
+
+baseline:
+   - moderately restrictive profile targeting standard application workloads with very basic security constraints.
+   - Cannot run as root by default.
+   - Disallows hostPath volumes (which allow Pods to access the host's file system).
+   - Prevents the use of certain Linux capabilities or privileged container execution.
+
+restricted:
+  - most restrictive profile ensuring compliance with high-security requirements.
+  - requires all containers to drop all unnecessary Linux capabilities.
+  - Disallows privileged containers and running as root.
+  - Does not allow access to the underlying host's file system or network.
+
+Set `privileged` profile at the namespace level:
 
 ```bash
 kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=restricted
-```
-
-### Secrets Management
-
-Kubernetes secrets allow to store sensitive configuration securely.
-1. Enable Secrets Encryption:
-
-Encrypt secrets at rest in etcd by enabling the `secrets` add-on within MicroK8s:
-```bash
-microk8s enable secrets
 ```
 
 ## Operational Hardening
@@ -66,11 +76,11 @@ The COS Stack offers a comprehensive set of observability tools such as Promethe
 
 Loki centralizes log data, allowing operators to correlate logs from multiple 5G Core services to quickly identify the root cause of errors, unusual activity, or potential security breaches.
 
-Notifications for critical incidents, such as resource exhaustion, node failures, or service disruptions, are managed and delivered through Alertmanager which is part of Prometheus. 
+Notifications for critical incidents, such as resource exhaustion, node failures or service disruptions are managed and delivered through Alertmanager which is part of Prometheus. 
 
 All of these observability features are accessible through Grafana, which provides customizable dashboards with actionable insights into the real-time health of the system.
 
-By integrating COS with Charmed Aether SD-Core, operators can establish a secure and resilient operational environment, proactively address issues, and ensure uninterrupted connectivity for end-users. 
+By integrating COS with Charmed Aether SD-Core, operators can establish a secure and resilient operational environment, proactively address issues and ensure uninterrupted connectivity for end-users. 
 
 Please follow [this guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/v1.5/how-to/integrate_sdcore_with_observability/) to integrate with Cos stack.
 

--- a/docs/explanation/hardening.md
+++ b/docs/explanation/hardening.md
@@ -1,0 +1,76 @@
+# Hardening
+
+## Infrastructure and Network Hardening
+
+### Operating System Security
+
+To ensure the security of operating systems in the deployment infrastructure (whether Virtual Machines or bare-metal servers), apply the following steps:
+
+1. Automate OS security patches:
+    - Enable automatic security updates to protect against newly discovered vulnerabilities.
+    - Tools for automatic updates such as `unattended-upgrades`.
+    
+2. Enable Secure Boot to ensure the system boots only trusted software, protecting against unauthorized code during startup.
+
+3. Disable Unused Modules and Network Services. Identify and disable OS kernel modules and network services that are not required for application functionality, reducing the system’s attack surface.
+
+### Firewall Rules
+
+Enforcing the firewall rules minimizes the attack surface while preserving the functionality required for operations.
+
+To enhance the security of the deployment infrastructure, firewalls are configured with the following rules:
+
+2. Allow only inbound traffic targeting the required ports for the 5G Core and the outgoing traffic required for communication with trusted endpoints.
+3. Allow Only Essential Protocols based on the 5G Core. Those are the required protocols:
+    - SCTP: For N2 interface communication (used by AMF).
+    - UDP: For PFCP (SMF <-> UPF) or GTP-U (UPF <-> RAN).
+    - TCP: For HTTP/HTTPS services like NRF or API communications.
+    - DNS/TLS: For Core service discovery and communication.
+
+All other protocols like FTP, Telnet, or legacy application protocols should be dropped unless explicitly needed.
+
+2. Protect Public Endpoints and Network Management System:
+    - Restrict access using IP whitelisting to allow only trusted IP ranges.
+    - Optionally, implement a VPN or private network to access management systems for additional security.
+
+## Hardening Containerized Applications
+
+### Enforce Pod Security
+Kubernetes offers Pod Security Standards (PSS) as a replacement for the deprecated Pod Security Policies (PSP). 
+MicroK8s uses the built-in Pod Security Admission controller to enforce these standards.
+1. Set Namespace-Level Pod Security Standards (PSS):
+
+Apply `restricted`, `baseline`, or `privileged` profiles at the namespace level:
+
+```bash
+kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=restricted
+```
+
+### Secrets Management
+
+Kubernetes secrets allow to store sensitive configuration securely.
+1. Enable Secrets Encryption:
+
+Encrypt secrets at rest in etcd by enabling the `secrets` add-on within MicroK8s:
+```bash
+microk8s enable secrets
+```
+
+## Operational Hardening
+
+### Monitoring and Alerts
+
+Monitoring and alerting are crucial for ensuring the secure and reliable operation of a 5G Core integrated with the Canonical Observability Stack (COS).
+
+The COS Stack offers a comprehensive set of observability tools such as Prometheus, Loki, Alertmanager, and Grafana to continuously monitor system performance, detect anomalies, and respond to potential security or operational issues.
+
+Loki centralizes log data, allowing operators to correlate logs from multiple 5G Core services to quickly identify the root cause of errors, unusual activity, or potential security breaches.
+
+Notifications for critical incidents, such as resource exhaustion, node failures, or service disruptions, are managed and delivered through Alertmanager which is part of Prometheus. 
+
+All of these observability features are accessible through Grafana, which provides customizable dashboards with actionable insights into the real-time health of the system.
+
+By integrating COS with Charmed Aether SD-Core, operators can establish a secure and resilient operational environment, proactively address issues, and ensure uninterrupted connectivity for end-users. 
+
+Please follow [this guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/v1.5/how-to/integrate_sdcore_with_observability/) to integrate with Cos stack.
+

--- a/docs/explanation/hardening.md
+++ b/docs/explanation/hardening.md
@@ -2,23 +2,9 @@
 
 ## Infrastructure Hardening
 
-### Operating System Security
-
-To ensure the security of operating systems in the deployment infrastructure (whether virtual machines or bare-metal servers), apply the following steps:
-
-1. Automate OS security patches.
-    - Enable automatic security updates to protect against newly discovered vulnerabilities.
-    - Use the tools for automatic updates such as `unattended-upgrades`.
-    
-2. Enable Secure Boot to ensure that the system boots only trusted software, protecting against unauthorized code during startup.
-
-3. Disable unused modules and network services. Identify and disable OS kernel modules and network services that are not required for application functionality, reducing the system’s attack surface.
-
 ### Firewall Rules
 
-Enforcing the firewall rules minimizes the attack surface while preserving the functionality required for operations.
-
-To enhance the security of the deployment infrastructure, firewalls can be configured with the following rules:
+Enforcing the firewall rules minimizes the attack surface while preserving the functionality required for operations. To enhance the security of the deployment infrastructure, firewalls can be configured with the following rules:
 
 1. Allow only inbound traffic targeting the required ports for the 5G Core and the outgoing traffic required for communication with trusted endpoints such as RAN and DN.
 2. Allow only essential protocols based on the 5G Core as follows:
@@ -31,21 +17,15 @@ To enhance the security of the deployment infrastructure, firewalls can be confi
 
 3. Protect public endpoints and Network Management System (NMS):
     - Restrict access using IP whitelisting to allow only trusted IP ranges.
-    - Optionally, implement a VPN or private network to access management systems for additional security.
+    - Optionally, deploy the core system behind a VPN or private network to enhance security for management systems.
 
 ## Hardening Containerized Applications
 
 ### Enforce Pod Security
 
-Kubernetes offers Pod Security Standards (PSS) as a replacement for the deprecated Pod Security Policies (PSP). MicroK8s uses the built-in Pod Security Admission controller to enforce these standards. There are three pod security admission profile levels:
+To align with Kubernetes security best practices, MicroK8s leverages the Pod Security Admission controller. When setting up namespaces, we recommend applying the `restricted` profile, which enforces the highest security standards required for production workloads.
 
-**Privileged** allows pods to run with elevated privileges and fewer security restrictions. It is needed for workloads that require extensive host access such as debugging tools, administrative pods.
-
-**Baseline** is moderately restrictive profile targeting standard application workloads with very basic security constraints. It cannot run as root by default and disallows hostPath volumes (which allow Pods to access the host's file system). Besides, it prevents the use of certain Linux capabilities or privileged container execution.
-
-**Restricted** is the most restrictive profile ensuring compliance with high-security requirements. It requires all containers to drop all unnecessary Linux capabilities, disallows privileged containers and running as root. It also does not allow access to the underlying host's file system or network.
-
-Set `restricted` profile at the namespace level:
+To apply the `restricted` profile at the namespace level, use the following command:
 
 ```bash
 kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=restricted
@@ -55,11 +35,6 @@ kubectl label namespace <namespace> pod-security.kubernetes.io/enforce=restricte
 
 ### Monitoring and Alerts
 
-Monitoring and alerting are crucial for ensuring the secure and reliable operation of a 5G Core integrated with the Canonical Observability Stack (COS). The COS Stack offers a comprehensive set of observability tools such as Prometheus, Loki, Alertmanager, and Grafana to continuously monitor system performance, detect anomalies, and respond to potential security or operational issues.
+Monitoring and alerting are essential for maintaining the secure and reliable operation of Charmed Aether SD-Core. By integrating COS with Charmed Aether SD-Core, operators can proactively address issues, maintain system resilience and ensure uninterrupted connectivity for end-users. For detailed steps, please follow [this guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/latest/how-to/integrate_sdcore_with_observability).
 
-Loki centralizes log data, allowing operators to correlate logs from multiple 5G Core services to quickly identify the root cause of errors, unusual activity, or potential security breaches. Notifications for critical incidents, such as resource exhaustion, node failures or service disruptions are managed and delivered through Alertmanager which is part of Prometheus. 
-
-All of these observability features are accessible through Grafana, which provides customizable dashboards with actionable insights into the real-time health of the system. By integrating COS with Charmed Aether SD-Core, operators can establish a secure and resilient operational environment, proactively address issues and ensure uninterrupted connectivity for end-users. 
-
-Please follow [this guide](https://canonical-charmed-aether-sd-core.readthedocs-hosted.com/en/v1.5/how-to/integrate_sdcore_with_observability) to integrate with COS stack.
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -5,6 +5,7 @@ The following explanations provide context and clarification on key-topics relat
 ```{toctree}
 :maxdepth: 1
 
+hardening
 security
 observability
 ```

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -18,11 +18,11 @@ By default, the TLS certificate provider employed is the [self-signed-certificat
 
 ## Access Control and Secure Communication in NMS
 
-The Charmed Aether SD-Core uses JWT-based authentication with role-based permissions to ensure secure access. Admin users have full control over all resources and accounts, while all other users have restricted permissions, limited to managing the resources they create and their own accounts. Authentication tokens expire after one hour, adding an extra layer of security. Furthermore, all HTTP endpoints in the Network Management System (NMS) are secured with HTTPS to ensure encrypted communication and prevent unauthorized interception.
+Charmed Aether SD-Core uses JWT-based authentication with role-based permissions to ensure secure access. Admin users have full control over all resources and accounts, while all other users have restricted permissions, limited to managing the resources they create and their own accounts. Authentication tokens expire after one hour. Furthermore, all HTTP endpoints in the Network Management System (NMS) are secured with HTTPS.
 
 ## Database Security
 
-The Charmed Aether SD-Core ensures security and isolation by keeping network functions, NMS users and subscribers' data in different databases.
+Charmed Aether SD-Core ensures security and isolation by keeping network functions, NMS users and subscribers' data in different databases.
 
 Granular access control restricts each database user's permissions to their respective data store, ensuring isolation, minimizing risks and enforcing the least privilege principle.
 
@@ -37,7 +37,7 @@ By ensuring validation and sanitization of certain inputs, the platform aims to 
 
 ## Log Confidentiality
 
-The Charmed Aether SD-Core adopts enhanced log confidentiality practices to ensure that sensitive or confidential data is excluded from log files.
+Charmed Aether SD-Core adopts enhanced log confidentiality practices to ensure that sensitive or confidential data is excluded from log files.
 
 - Subscriber authentication tokens or identifiers such as location
 - Encryption keys
@@ -47,9 +47,7 @@ By adhering to these practices, the platform prevents unintended disclosure of c
 
 ## Secure Dependencies
 
-All libraries and dependencies utilized in Juju charms are continuously monitored, scanned, and updated using **Renovate**. This automation ensures:
+All libraries and dependencies utilized in Juju charms are continuously monitored, scanned, and updated. This automation ensures:
 
 - The use of up-to-date libraries and dependencies.
 - Identification and mitigation of vulnerabilities in third-party packages.
-
-By leveraging Renovate, the platform ensures that all Juju charms remain secure and aligned with the latest updates, reducing risks associated with outdated or vulnerable code.

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -38,9 +38,7 @@ Access to these databases is tightly controlled by granting different database u
 
 ## Input Validation
 
-Comprehensive input validation is implemented within charms and the Network Management System (NMS) to mitigate the risk of injection attacks and ensure secure handling of user-provided inputs. 
-
-This validation applies to inputs used for:
+Comprehensive input validation is implemented within charms and the Network Management System (NMS) to mitigate the risk of injection attacks and ensure secure handling of user-provided inputs. This validation applies to inputs used for:
 
 - Configuring the Network Management System (NMS)
 - Managing and operating charms

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -59,7 +59,7 @@ By adhering to these practices, the platform prevents unintended disclosure of c
 
 ## Secure Dependencies
 
-All libraries and dependencies utilized in Juju charms are continuously monitored, scanned, and updated using Renovate. This automation ensures:
+All libraries and dependencies utilized in Juju charms are continuously monitored, scanned, and updated using **Renovate**. This automation ensures:
 
 - The use of up-to-date libraries and dependencies.
 - Identification and mitigation of vulnerabilities in third-party packages.

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -15,3 +15,62 @@ Charmed Aether SD-Core enforces TLS encryption across all communication within t
 Each Charmed Aether SD-Core charm generates its private key and a certificate signing request (CSR). The CSR is then transmitted to a TLS certificate provider, which in turn signs the certificate and sends it back to the charm. Subsequently, the 5G network function utilizes this certificate to encrypt its communications with other network functions.
 
 By default, the TLS certificate provider employed is the [self-signed-certificates operator](https://charmhub.io/self-signed-certificates). However, users have the flexibility to utilize any TLS certificates provider as long as it supports the `tls-certificates` integration.
+
+inimized chiseled container images and TLS encryption, to provide a comprehensive, secure platform for 5G network functions.
+
+## Access Control and Secure Communication in NMS
+
+Charmed Aether SD-Core platform implements strict access controls and role-based permissions. Other than the admin user, all users are granted limited permissions, ensuring that they can only access, edit, or delete the resources they have created. These include slices, device groups, and subscriber-related configurations. Additionally, each user can only view and manage their own account and has the ability to change their own password.
+
+The admin user, however, has full control over the platform. These capabilities include creating and deleting users, managing all resources (slices, device groups, subscribers, etc.), and viewing and editing all accounts. This hierarchical access control provides a secure and organized way to manage users and resources within the system.
+
+To further enhance security, authentication tokens are valid for only one hour. This ensures that access to the platform remains temporary and reduces the risk of unauthorized access in case a token is exposed. This layered security model ensures that permissions are strictly enforced, reducing potential risks and maintaining the integrity of the Charmed Aether SD-Core platform.
+
+Additionally, all HTTP endpoints in the Network Management System (NMS) are secured using HTTPS. This encrypts data in transit and mitigates risks of man-in-the-middle (MITM) attacks. With strong TLS implementations, HTTPS ensures secure connections and protects sensitive information transmitted within the system.
+
+### Implementation of Short-Lived Tokens
+
+To ensure secure interaction between the Network Management System (NMS) and its users, the use of short-lived tokens is implemented with the following details:
+
+- **Default Time-to-Live (TTL)**: Authentication tokens are set to expire after 1 hour.
+- **Re-authentication Requirement**: Users or applications must re-authenticate upon token expiration.
+
+Implementing short-lived tokens reduces the risk of session credential misuse by limiting the window of exposure in case of token compromise.
+
+## Database Security
+
+To ensure enhanced security and organization, the Charmed Aether SD-Core platform implements three distinct and isolated data stores. Each data store is dedicated to a specific type of data:
+
+- **Network Functions (NFs) data**: Stores information related to configurations, operations and the policies of 5G Core network.
+- **Subscriber data**: Contains authentication data and other details related to subscribers.
+- **NMS users data**: Manages data specific to the Network Management System (NMS), including user information, roles, and access permissions.
+
+Access to these databases is tightly controlled by granting different database users the necessary permissions to only access their respective data stores. This granular access control ensures that each database is securely isolated, which reduces risks, prevents unauthorized access, and enforces the principle of least privilege.
+
+## Input Validation
+
+Comprehensive input validation is implemented within charms and the Network Management System (NMS) to mitigate the risk of injection attacks and ensure secure handling of user-provided inputs. This validation applies to inputs used for:
+
+- Configuring the Network Management System (NMS)
+- Managing and operating charms
+
+By performing thorough validation and sanitization of inputs in these components, the platform effectively prevents vulnerabilities such as SQL injection, command injection, and other malicious exploitation attempts. This ensures the integrity and security of the platform's underlying systems and protects against unauthorized access or data manipulation.
+
+## Log Confidentiality
+
+The Charmed Aether SD-Core platform enforces strict log confidentiality standards to ensure that sensitive or confidential data is never included in log files. This policy applies to all Network Function logging frameworks and ensures the exclusion of:
+
+- Subscriber authentication tokens or identifiers such as location
+- Encryption keys
+- Configuration secrets or network-specific credentials
+
+By adhering to these practices, the platform prevents unintended disclosure of confidential information through logging mechanisms, ensuring privacy and maintaining regulatory compliance.
+
+## Secure Dependencies
+
+All libraries and dependencies utilized in Juju charms are continuously monitored, scanned, and updated using **Renovate**. This automation ensures:
+
+- The use of up-to-date libraries and dependencies.
+- Identification and mitigation of vulnerabilities in third-party packages.
+
+By leveraging Renovate, the platform ensures that all Juju charms remain secure and aligned with the latest updates, reducing risks associated with outdated or vulnerable code.

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -18,42 +18,32 @@ By default, the TLS certificate provider employed is the [self-signed-certificat
 
 ## Access Control and Secure Communication in NMS
 
-Charmed Aether SD-Core platform implements strict access controls and role-based permissions. Other than the admin user, all users are granted limited permissions, ensuring that they can only access, edit, or delete the resources they have created. These include slices, device groups and subscribers. Additionally, each user can only view and manage their own account and has ability to change their own password.
-
-The admin user, however, has full control over the platform. These capabilities include creating and deleting users, managing all resources (slices, device groups, subscribers, etc.), and viewing and editing all accounts. This hierarchical access control provides a secure and organized way to manage users and resources within the system.
-
-To further enhance security, authentication tokens are valid for only one hour. This ensures that access to the platform remains temporary and reduces the risk of unauthorized access in case a token is exposed. This layered security model ensures that permissions are strictly enforced, reducing potential risks and maintaining the integrity of the Charmed Aether SD-Core platform.
-
-Additionally, all HTTP endpoints in the Network Management System (NMS) are secured using HTTPS. This encrypts data in transit and mitigates risks of man-in-the-middle (MITM) attacks. With strong TLS implementations, HTTPS ensures secure connections and protects sensitive information transmitted within the system.
+The Charmed Aether SD-Core uses JWT-based authentication with role-based permissions to ensure secure access. Admin users have full control over all resources and accounts, while all other users have restricted permissions, limited to managing the resources they create and their own accounts. Authentication tokens expire after one hour, adding an extra layer of security. Furthermore, all HTTP endpoints in the Network Management System (NMS) are secured with HTTPS to ensure encrypted communication and prevent unauthorized interception.
 
 ## Database Security
 
-To ensure enhanced security and organization, the Charmed Aether SD-Core platform implements three distinct and isolated data stores. Each data store is dedicated to a specific type of data:
+The Charmed Aether SD-Core ensures security and isolation by keeping network functions, NMS users and subscribers' data in different databases.
 
-- Network Functions (NFs) data: Stores information related to configurations, operations and the policies of 5G Core network.
-- Subscriber data: Contains authentication data and other details related to subscribers.
-- NMS users data: Manages data specific to the Network Management System (NMS), including user information, roles, and access permissions.
-
-Access to these databases is tightly controlled by granting different database users the necessary permissions to only access their respective data stores. This granular access control ensures that each database is securely isolated, which reduces risks, prevents unauthorized access, and enforces the principle of least privilege.
+Granular access control restricts each database user's permissions to their respective data store, ensuring isolation, minimizing risks and enforcing the least privilege principle.
 
 ## Input Validation
 
-Comprehensive input validation is implemented within charms and the Network Management System (NMS) to mitigate the risk of injection attacks and ensure secure handling of user-provided inputs. This validation applies to inputs used for:
+Input validation mechanisms are implemented within charms and the Network Management System (NMS) to enhance the secure handling of user-provided inputs. These validations primarily target inputs used for:
 
 - Configuring the Network Management System (NMS)
 - Managing and operating charms
 
-By performing thorough validation and sanitization of inputs in these components, the platform effectively prevents vulnerabilities such as SQL injection, command injection, and other malicious exploitation attempts. This ensures the integrity and security of the platform's underlying systems and protects against unauthorized access or data manipulation.
+By ensuring validation and sanitization of certain inputs, the platform aims to reduce the risks associated with vulnerabilities like SQL injection, command injection, and exploitation attempts.
 
 ## Log Confidentiality
 
-The Charmed Aether SD-Core platform enforces strict log confidentiality standards to ensure that sensitive or confidential data is never included in log files. This policy applies to all Network Function logging frameworks and ensures the exclusion of:
+The Charmed Aether SD-Core adopts enhanced log confidentiality practices to ensure that sensitive or confidential data is excluded from log files.
 
 - Subscriber authentication tokens or identifiers such as location
 - Encryption keys
 - Configuration secrets or network-specific credentials
 
-By adhering to these practices, the platform prevents unintended disclosure of confidential information through logging mechanisms, ensuring privacy and maintaining regulatory compliance.
+By adhering to these practices, the platform prevents unintended disclosure of confidential information through logging mechanisms and ensures privacy.
 
 ## Secure Dependencies
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -16,49 +16,52 @@ Each Charmed Aether SD-Core charm generates its private key and a certificate si
 
 By default, the TLS certificate provider employed is the [self-signed-certificates operator](https://charmhub.io/self-signed-certificates). However, users have the flexibility to utilize any TLS certificates provider as long as it supports the `tls-certificates` integration.
 
-inimized chiseled container images and TLS encryption, to provide a comprehensive, secure platform for 5G network functions.
-
 ## Access Control and Secure Communication in NMS
 
-Charmed Aether SD-Core platform implements strict access controls and role-based permissions. Other than the admin user, all users are granted limited permissions, ensuring that they can only access, edit, or delete the resources they have created. These include slices, device groups, and subscriber-related configurations. Additionally, each user can only view and manage their own account and has the ability to change their own password.
+Charmed Aether SD-Core platform implements strict access controls and role-based permissions. Other than the admin user, all users are granted limited permissions, ensuring that they can only access, edit, or delete the resources they have created. 
 
-The admin user, however, has full control over the platform. These capabilities include creating and deleting users, managing all resources (slices, device groups, subscribers, etc.), and viewing and editing all accounts. This hierarchical access control provides a secure and organized way to manage users and resources within the system.
+These include slices, device groups and subscribers. Additionally, each user can only view and manage their own account and has ability to change their own password.
 
-To further enhance security, authentication tokens are valid for only one hour. This ensures that access to the platform remains temporary and reduces the risk of unauthorized access in case a token is exposed. This layered security model ensures that permissions are strictly enforced, reducing potential risks and maintaining the integrity of the Charmed Aether SD-Core platform.
+The admin user, however, has full control over the platform. These capabilities include creating and deleting users, managing all resources (slices, device groups, subscribers, etc.), and viewing and editing all accounts. 
+
+This hierarchical access control provides a secure and organized way to manage users and resources within the system.
+
+To further enhance security, authentication tokens are valid for only one hour. This ensures that access to the platform remains temporary and reduces the risk of unauthorized access in case a token is exposed. 
+
+This layered security model ensures that permissions are strictly enforced, reducing potential risks and maintaining the integrity of the Charmed Aether SD-Core platform.
 
 Additionally, all HTTP endpoints in the Network Management System (NMS) are secured using HTTPS. This encrypts data in transit and mitigates risks of man-in-the-middle (MITM) attacks. With strong TLS implementations, HTTPS ensures secure connections and protects sensitive information transmitted within the system.
-
-### Implementation of Short-Lived Tokens
-
-To ensure secure interaction between the Network Management System (NMS) and its users, the use of short-lived tokens is implemented with the following details:
-
-- **Default Time-to-Live (TTL)**: Authentication tokens are set to expire after 1 hour.
-- **Re-authentication Requirement**: Users or applications must re-authenticate upon token expiration.
-
-Implementing short-lived tokens reduces the risk of session credential misuse by limiting the window of exposure in case of token compromise.
 
 ## Database Security
 
 To ensure enhanced security and organization, the Charmed Aether SD-Core platform implements three distinct and isolated data stores. Each data store is dedicated to a specific type of data:
 
-- **Network Functions (NFs) data**: Stores information related to configurations, operations and the policies of 5G Core network.
-- **Subscriber data**: Contains authentication data and other details related to subscribers.
-- **NMS users data**: Manages data specific to the Network Management System (NMS), including user information, roles, and access permissions.
+- Network Functions (NFs) data: Stores information related to configurations, operations and the policies of 5G Core network.
+- Subscriber data: Contains authentication data and other details related to subscribers.
+- NMS users data: Manages data specific to the Network Management System (NMS), including user information, roles, and access permissions.
 
-Access to these databases is tightly controlled by granting different database users the necessary permissions to only access their respective data stores. This granular access control ensures that each database is securely isolated, which reduces risks, prevents unauthorized access, and enforces the principle of least privilege.
+Access to these databases is tightly controlled by granting different database users the necessary permissions to only access their respective data stores. 
+
+This granular access control ensures that each database is securely isolated, which reduces risks, prevents unauthorized access, and enforces the principle of least privilege.
 
 ## Input Validation
 
-Comprehensive input validation is implemented within charms and the Network Management System (NMS) to mitigate the risk of injection attacks and ensure secure handling of user-provided inputs. This validation applies to inputs used for:
+Comprehensive input validation is implemented within charms and the Network Management System (NMS) to mitigate the risk of injection attacks and ensure secure handling of user-provided inputs. 
+
+This validation applies to inputs used for:
 
 - Configuring the Network Management System (NMS)
 - Managing and operating charms
 
-By performing thorough validation and sanitization of inputs in these components, the platform effectively prevents vulnerabilities such as SQL injection, command injection, and other malicious exploitation attempts. This ensures the integrity and security of the platform's underlying systems and protects against unauthorized access or data manipulation.
+By performing through validation and sanitization of inputs in these components, the platform effectively prevents vulnerabilities such as SQL injection, command injection, and other malicious exploitation attempts. 
+
+This ensures the integrity and security of the platform's underlying systems and protects against unauthorized access or data manipulation.
 
 ## Log Confidentiality
 
-The Charmed Aether SD-Core platform enforces strict log confidentiality standards to ensure that sensitive or confidential data is never included in log files. This policy applies to all Network Function logging frameworks and ensures the exclusion of:
+The Charmed Aether SD-Core platform enforces strict log confidentiality standards to ensure that sensitive or confidential data is never included in log files.
+
+This policy applies to all Network Function logging frameworks and ensures the exclusion of:
 
 - Subscriber authentication tokens or identifiers such as location
 - Encryption keys
@@ -68,7 +71,9 @@ By adhering to these practices, the platform prevents unintended disclosure of c
 
 ## Secure Dependencies
 
-All libraries and dependencies utilized in Juju charms are continuously monitored, scanned, and updated using **Renovate**. This automation ensures:
+All libraries and dependencies utilized in Juju charms are continuously monitored, scanned, and updated using Renovate. 
+
+This automation ensures:
 
 - The use of up-to-date libraries and dependencies.
 - Identification and mitigation of vulnerabilities in third-party packages.

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -45,7 +45,7 @@ This validation applies to inputs used for:
 - Configuring the Network Management System (NMS)
 - Managing and operating charms
 
-By performing through validation and sanitization of inputs in these components, the platform effectively prevents vulnerabilities such as SQL injection, command injection, and other malicious exploitation attempts. This ensures the integrity and security of the platform's underlying systems and protects against unauthorized access or data manipulation.
+By performing thorough validation and sanitization of inputs in these components, the platform effectively prevents vulnerabilities such as SQL injection, command injection, and other malicious exploitation attempts. This ensures the integrity and security of the platform's underlying systems and protects against unauthorized access or data manipulation.
 
 ## Log Confidentiality
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -18,17 +18,11 @@ By default, the TLS certificate provider employed is the [self-signed-certificat
 
 ## Access Control and Secure Communication in NMS
 
-Charmed Aether SD-Core platform implements strict access controls and role-based permissions. Other than the admin user, all users are granted limited permissions, ensuring that they can only access, edit, or delete the resources they have created. 
+Charmed Aether SD-Core platform implements strict access controls and role-based permissions. Other than the admin user, all users are granted limited permissions, ensuring that they can only access, edit, or delete the resources they have created. These include slices, device groups and subscribers. Additionally, each user can only view and manage their own account and has ability to change their own password.
 
-These include slices, device groups and subscribers. Additionally, each user can only view and manage their own account and has ability to change their own password.
+The admin user, however, has full control over the platform. These capabilities include creating and deleting users, managing all resources (slices, device groups, subscribers, etc.), and viewing and editing all accounts. This hierarchical access control provides a secure and organized way to manage users and resources within the system.
 
-The admin user, however, has full control over the platform. These capabilities include creating and deleting users, managing all resources (slices, device groups, subscribers, etc.), and viewing and editing all accounts. 
-
-This hierarchical access control provides a secure and organized way to manage users and resources within the system.
-
-To further enhance security, authentication tokens are valid for only one hour. This ensures that access to the platform remains temporary and reduces the risk of unauthorized access in case a token is exposed. 
-
-This layered security model ensures that permissions are strictly enforced, reducing potential risks and maintaining the integrity of the Charmed Aether SD-Core platform.
+To further enhance security, authentication tokens are valid for only one hour. This ensures that access to the platform remains temporary and reduces the risk of unauthorized access in case a token is exposed. This layered security model ensures that permissions are strictly enforced, reducing potential risks and maintaining the integrity of the Charmed Aether SD-Core platform.
 
 Additionally, all HTTP endpoints in the Network Management System (NMS) are secured using HTTPS. This encrypts data in transit and mitigates risks of man-in-the-middle (MITM) attacks. With strong TLS implementations, HTTPS ensures secure connections and protects sensitive information transmitted within the system.
 
@@ -40,9 +34,7 @@ To ensure enhanced security and organization, the Charmed Aether SD-Core platfor
 - Subscriber data: Contains authentication data and other details related to subscribers.
 - NMS users data: Manages data specific to the Network Management System (NMS), including user information, roles, and access permissions.
 
-Access to these databases is tightly controlled by granting different database users the necessary permissions to only access their respective data stores. 
-
-This granular access control ensures that each database is securely isolated, which reduces risks, prevents unauthorized access, and enforces the principle of least privilege.
+Access to these databases is tightly controlled by granting different database users the necessary permissions to only access their respective data stores. This granular access control ensures that each database is securely isolated, which reduces risks, prevents unauthorized access, and enforces the principle of least privilege.
 
 ## Input Validation
 
@@ -53,15 +45,11 @@ This validation applies to inputs used for:
 - Configuring the Network Management System (NMS)
 - Managing and operating charms
 
-By performing through validation and sanitization of inputs in these components, the platform effectively prevents vulnerabilities such as SQL injection, command injection, and other malicious exploitation attempts. 
-
-This ensures the integrity and security of the platform's underlying systems and protects against unauthorized access or data manipulation.
+By performing through validation and sanitization of inputs in these components, the platform effectively prevents vulnerabilities such as SQL injection, command injection, and other malicious exploitation attempts. This ensures the integrity and security of the platform's underlying systems and protects against unauthorized access or data manipulation.
 
 ## Log Confidentiality
 
-The Charmed Aether SD-Core platform enforces strict log confidentiality standards to ensure that sensitive or confidential data is never included in log files.
-
-This policy applies to all Network Function logging frameworks and ensures the exclusion of:
+The Charmed Aether SD-Core platform enforces strict log confidentiality standards to ensure that sensitive or confidential data is never included in log files. This policy applies to all Network Function logging frameworks and ensures the exclusion of:
 
 - Subscriber authentication tokens or identifiers such as location
 - Encryption keys
@@ -71,9 +59,7 @@ By adhering to these practices, the platform prevents unintended disclosure of c
 
 ## Secure Dependencies
 
-All libraries and dependencies utilized in Juju charms are continuously monitored, scanned, and updated using Renovate. 
-
-This automation ensures:
+All libraries and dependencies utilized in Juju charms are continuously monitored, scanned, and updated using Renovate. This automation ensures:
 
 - The use of up-to-date libraries and dependencies.
 - Identification and mitigation of vulnerabilities in third-party packages.


### PR DESCRIPTION
# Description
 
The security section is expanded by mentioning about Access Control and secure Communication in NMS, Database Security, Input Validation, Log Confidentiality and Secure Dependencies.
Besides, a hardening guide is added which recommends to harden Infrastructure and Containerized Applications. In addition, the operational hardening sections advises to use COS stack to visualize the unusual activities or potential security breaches.

There is not an applicable hardening method for Charmed Aether SD-Core in application level for the moment. In this area, a potential feature is being proposed: https://warthogs.atlassian.net/jira/software/c/projects/TELCO/boards/1079/backlog?selectedIssue=TELCO-1707. 


# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
