### PR TITLE
chore: remove router from sdcore deployment

### DIFF
--- a/docs/reference/components.md
+++ b/docs/reference/components.md
@@ -15,7 +15,6 @@ Charmed Aether SD-Core `v1.6` is composed of the following components and their 
 | {bdg-link-primary-line}`NRF  <https://charmhub.io/sdcore-nrf-k8s>`                                | 1.6/edge           | 1.6                  |
 | {bdg-link-primary-line}`NSSF  <https://charmhub.io/sdcore-nssf-k8s>`                              | 1.6/edge           | 1.6                  |
 | {bdg-link-primary-line}`PCF  <https://charmhub.io/sdcore-pcf-k8s>`                                | 1.6/edge           | 1.6                  |
-| {bdg-link-primary-line}`Router  <https://charmhub.io/sdcore-router-k8s>`                          | 1.6/edge           | 0.1                  |
 | {bdg-link-primary-line}`SMF  <https://charmhub.io/sdcore-smf-k8s>`                                | 1.6/edge           | 2.0                  |
 | {bdg-link-primary-line}`UDM  <https://charmhub.io/sdcore-udm-k8s>`                                | 1.6/edge           | 1.6                  |
 | {bdg-link-primary-line}`UDR  <https://charmhub.io/sdcore-udr-k8s>`                                | 1.6/edge           | 1.6                  |

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -1,14 +1,9 @@
 # Getting started
 
 In this tutorial, we will deploy and run an SD-Core 5G core network using Juju and Terraform.
-As part of this tutorial, we will also deploy additional components:
+As part of this tutorial, we will also deploy a gNB Simulator which is a 5G radio and a cellphone simulator.
 
-- gNB Simulator: a 5G radio and a cellphone simulator,
-- SD-Core Router: a software router facilitating communication between the core and the Radio
- Access Network (RAN) to simulate usage of this network.
-
-Both gNB Simulator and SD-Core Router serve only demonstration purposes and shouldn't be part
- of production deployments.
+The gNB Simulator serve only demonstration purposes and shouldn't be part of production deployments.
 
 To complete this tutorial, you will need a machine which meets the following requirements:
 
@@ -100,7 +95,7 @@ terraform {
 EOF
 ```
 
-Create a Terraform module containing the SD-Core 5G core network and a router:
+Create a Terraform module containing the SD-Core 5G core network:
 
 ```console
 cat << EOF > core.tf
@@ -108,18 +103,10 @@ resource "juju_model" "sdcore" {
   name = "sdcore"
 }
 
-module "sdcore-router" {
-  source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform"
-
-  model      = juju_model.sdcore.name
-  depends_on = [juju_model.sdcore]
-}
-
 module "sdcore" {
   source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
 
   model        = juju_model.sdcore.name
-  depends_on = [module.sdcore-router]
   
   traefik_config = {
     routing_mode = "subdomain"
@@ -173,8 +160,7 @@ mongodb                            active       1  mongodb-k8s               6/s
 nms                       1.1.0    active       1  sdcore-nms-k8s            1.6/edge       849  10.152.183.42   no       
 nrf                       1.6.2    active       1  sdcore-nrf-k8s            1.6/edge       790  10.152.183.234  no       
 nssf                      1.6.1    active       1  sdcore-nssf-k8s           1.6/edge       669  10.152.183.40   no       
-pcf                       1.6.1    active       1  sdcore-pcf-k8s            1.6/edge       710  10.152.183.129  no       
-router                             active       1  sdcore-router-k8s         1.6/edge       464  10.152.183.176  no       
+pcf                       1.6.1    active       1  sdcore-pcf-k8s            1.6/edge       710  10.152.183.129  no           
 self-signed-certificates           active       1  self-signed-certificates  1/stable       263  10.152.183.71   no       
 smf                       2.0.2    active       1  sdcore-smf-k8s            1.6/edge       801  10.152.183.81   no       
 traefik                   2.11.0   blocked      1  traefik-k8s               latest/stable  234  10.152.183.244  no       "external_hostname" must be set while using routing mode "subdomain"
@@ -190,8 +176,7 @@ mongodb/0*                   active    idle   10.1.194.237         Primary
 nms/0*                       active    idle   10.1.194.255         
 nrf/0*                       active    idle   10.1.194.213         
 nssf/0*                      active    idle   10.1.194.243         
-pcf/0*                       active    idle   10.1.194.250         
-router/0*                    active    idle   10.1.194.210         
+pcf/0*                       active    idle   10.1.194.250                 
 self-signed-certificates/0*  active    idle   10.1.194.239         
 smf/0*                       active    idle   10.1.194.202         
 traefik/0*                   blocked   idle   10.1.194.230         "external_hostname" must be set while using routing mode "subdomain"
@@ -258,7 +243,6 @@ module "gnbsim" {
   source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
 
   model      = juju_model.ran-simulator.name
-  depends_on = [module.sdcore-router]
 }
 
 resource "juju_integration" "gnbsim-amf" {

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -107,6 +107,7 @@ module "sdcore" {
   source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
 
   model        = juju_model.sdcore.name
+  depends_on = [juju_model.sdcore]
   
   traefik_config = {
     routing_mode = "subdomain"

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -3,7 +3,7 @@
 In this tutorial, we will deploy and run an SD-Core 5G core network using Juju and Terraform.
 As part of this tutorial, we will also deploy a gNB Simulator which is a 5G radio and a cellphone simulator.
 
-The gNB Simulator serve only demonstration purposes and shouldn't be part of production deployments.
+The gNB Simulator serves only demonstration purposes and shouldn't be part of production deployments.
 
 To complete this tutorial, you will need a machine which meets the following requirements:
 

--- a/examples/terraform/getting_started/core.tf
+++ b/examples/terraform/getting_started/core.tf
@@ -5,18 +5,11 @@ resource "juju_model" "sdcore" {
   name = "sdcore"
 }
 
-module "sdcore-router" {
-  source = "git::https://github.com/canonical/sdcore-router-k8s-operator//terraform"
-
-  model      = juju_model.sdcore.name
-  depends_on = [juju_model.sdcore]
-}
 
 module "sdcore" {
   source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
 
   model      = juju_model.sdcore.name
-  depends_on = [module.sdcore-router]
 
   traefik_config = {
     routing_mode = "subdomain"

--- a/examples/terraform/getting_started/core.tf
+++ b/examples/terraform/getting_started/core.tf
@@ -10,6 +10,7 @@ module "sdcore" {
   source = "git::https://github.com/canonical/terraform-juju-sdcore//modules/sdcore-k8s"
 
   model      = juju_model.sdcore.name
+  depends_on = [juju_model.sdcore]
 
   traefik_config = {
     routing_mode = "subdomain"

--- a/examples/terraform/getting_started/ran.tf
+++ b/examples/terraform/getting_started/ran.tf
@@ -9,7 +9,6 @@ module "gnbsim" {
   source = "git::https://github.com/canonical/sdcore-gnbsim-k8s-operator//terraform"
 
   model      = juju_model.ran-simulator.name
-  depends_on = [module.sdcore-router]
 }
 
 resource "juju_integration" "gnbsim-amf" {


### PR DESCRIPTION
# Description

UPF charm started to set IP masquerade on the core interface within this [PR](https://github.com/canonical/sdcore-upf-k8s-operator/pull/67). After UPF started to support NATting, router is unnecessary for SD-Core deployments. Hence, this PR removed the router deployment as it has no effect now.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
