### PR TITLE
chore: remove Sequence Number from tutorials

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -404,7 +404,7 @@ Navigate to `Subscribers` tab and click the `Create` button. Fill in the followi
 - Network Slice: `default`
 - Device Group: `device-group`
 
-Click the two `Generate` buttons to automatically fill in the values in the form. Note the IMSI, OPC, Key and Sequence Number; we are going to use them in the next step.
+Click the two `Generate` buttons to automatically fill in the values in the form. Note the IMSI, OPC, and Key; we are going to use them in the next step.
 
 After clicking the `Submit` button you should see the subscriber created:
 
@@ -419,7 +419,7 @@ Switch to the `ran` model and set up the subscriber information using the values
 
 ```console
 juju switch ran
-juju config gnbsim imsi=<IMSI> usim-opc=<OPC> usim-key=<Key> usim-sequence-number=<Sequence Number>
+juju config gnbsim imsi=<IMSI> usim-opc=<OPC> usim-key=<Key>
 ```
 
 Make sure that the `gnbsim` application is in `Active/Idle` state.

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -551,7 +551,7 @@ Navigate to `Subscribers` tab and click the `Create` button. Fill in the followi
 - Network Slice: `Tutorial`
 - Device Group: `device-group`
 
-Click the two `Generate` buttons to automatically fill in the values in the form. Note the IMSI, OPC, Key and Sequence Number; we are going to use them shortly.
+Click the two `Generate` buttons to automatically fill in the values in the form. Note the IMSI, OPC, and Key; we are going to use them shortly.
 
 After clicking the `Submit` button you should see the subscriber created:
 
@@ -722,7 +722,7 @@ On the `juju-controller` VM, switch to the `gnbsim` model and set up the subscri
 
 ```console
 juju switch gnbsim
-juju config gnbsim imsi=<IMSI> usim-opc=<OPC> usim-key=<Key> usim-sequence-number=<Sequence Number>
+juju config gnbsim imsi=<IMSI> usim-opc=<OPC> usim-key=<Key>
 
 ```
 Wait for the `gnbsim` status to be `Active/Idle`.


### PR DESCRIPTION
# Description

This PR removes the reference to Sequence Number in `Getting Started` and `Mastering` tutorials, according to https://github.com/canonical/sdcore-gnbsim-k8s-operator/pull/413.

# Checklist:

- [x] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
