### PR TITLE
fix: set grafana agent channel to 1/stable

### DIFF
--- a/docs/reference/components.md
+++ b/docs/reference/components.md
@@ -4,7 +4,7 @@ Charmed Aether SD-Core `v1.6` is composed of the following components and their 
 
 | **Charm**                                                                                         | **CharmHub Track** | **Workload version** |
 | :------------------------------------------------------------------------------------------------ | :----------------- | :------------------- |
-| {bdg-link-primary-line}`Grafana Agent  <https://charmhub.io/grafana-agent-k8s>`                   | latest/stable      | 0                    |
+| {bdg-link-primary-line}`Grafana Agent  <https://charmhub.io/grafana-agent-k8s>`                   | 1/stable           | 0                    |
 | {bdg-link-primary-line}`MongoDB  <https://charmhub.io/mongodb-k8s>`                               | 6/stable           | 6                    |
 | {bdg-link-primary-line}`Self Signed Certificates  <https://charmhub.io/self-signed-certificates>` | 1/stable           | N/A                  |
 | {bdg-link-primary-line}`Traefik  <https://charmhub.io/self-signed-certificates>`                  | latest/stable      | 2                    |

--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -169,7 +169,7 @@ sdcore  k8s         k8s           3.6.6    unsupported  11:35:07+02:00
 App                       Version  Status   Scale  Charm                     Channel        Rev  Address         Exposed  Message
 amf                       1.6.4    active       1  sdcore-amf-k8s            1.6/edge       908  10.152.183.217  no       
 ausf                      1.6.2    active       1  sdcore-ausf-k8s           1.6/edge       713  10.152.183.19   no       
-grafana-agent             0.40.4   blocked      1  grafana-agent-k8s         latest/stable  111  10.152.183.102  no       Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
+grafana-agent             0.40.4   blocked      1  grafana-agent-k8s         1/stable       111  10.152.183.102  no       Missing ['grafana-cloud-config']|['logging-consumer'] for logging-provider; ['grafana-cloud-config']|['send-remote-wr...
 mongodb                            active       1  mongodb-k8s               6/stable        61  10.152.183.18   no       
 nms                       1.1.0    active       1  sdcore-nms-k8s            1.6/edge       849  10.152.183.42   no       
 nrf                       1.6.2    active       1  sdcore-nrf-k8s            1.6/edge       790  10.152.183.234  no       


### PR DESCRIPTION
# Description

Grafana agent charm has been release to `1/stable`. This PR updates it

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
