### PR TITLE
fix: perform configuration with terraform modules

### DIFF
--- a/docs/tutorials/getting_started.md
+++ b/docs/tutorials/getting_started.md
@@ -435,13 +435,36 @@ After clicking the `Submit` button you should see the subscriber created:
 :align: center
 ```
 
+### Set up the subscriber information using Terraform module
+
+To configure gnbsim with the subscriber information, add a config block to the gnbsim module in your `ran.tf` file. 
+
+Replace the placeholders with the values you noted earlier:
+
+```
+:caption: ran.tf
+module "gnbsim" {
+  # ...
+  config = {
+    imsi      = "<IMSI>"
+    usim-opc  = "<OPC>"
+    usim-key  = "<Key>"
+  }
+  # ...
+```
+
+Apply the updated configuration:
+
+```console
+terraform apply -auto-approve
+```
+
 ## 8. Run the 5G simulation
 
-Switch to the `ran` model and set up the subscriber information using the values noted in the previous step:
+Switch to the `ran` model:
 
 ```console
 juju switch ran
-juju config gnbsim imsi=<IMSI> usim-opc=<OPC> usim-key=<Key>
 ```
 
 Make sure that the `gnbsim` application is in `Active/Idle` state.

--- a/docs/tutorials/mastering.md
+++ b/docs/tutorials/mastering.md
@@ -716,14 +716,37 @@ Keep this page open, we will revisit it shortly.
 It may take up to 5 minutes for the relevant metrics to be available in Prometheus.
 ```
 
+### Set up the subscriber information using Terraform module
+
+From the `juju-controller` VM, add a config block to the `gnbsim` module in your `main.tf` file to configure gnbsim with the subscriber information. 
+
+Replace the placeholders with the values noted in [step 6](#6-configure-sd-core).
+
+```
+:caption: main.tf
+module "gnbsim" {
+  # ...
+  config = {
+    (...)
+    imsi      = "<IMSI>"
+    usim-opc  = "<OPC>"
+    usim-key  = "<Key>"
+  }
+  # ...
+```
+
+Apply the updated configuration:
+
+```console
+terraform apply -auto-approve
+```
+
 ## 8. Run the 5G simulation
 
-On the `juju-controller` VM, switch to the `gnbsim` model and set up the subscriber information using the values noted in [step 6](#6-configure-sd-core).
+Switch to the `gnbsim` model:
 
 ```console
 juju switch gnbsim
-juju config gnbsim imsi=<IMSI> usim-opc=<OPC> usim-key=<Key>
-
 ```
 Wait for the `gnbsim` status to be `Active/Idle`.
 


### PR DESCRIPTION
# Description

Use TF modules for setting gnbsim config in tutorials.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
