### PR TITLE
docs: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Charmed Aether SD-Core
 
+> **:warning: Deprecation Notice!**
+>
+> This project is deprecated and will not receive further updates. Please refer to the upstream [Aether](https://aetherproject.org/) project to continue using Aether.
+
 Charmed Aether SD-Core automates the operations of Aether SD-Core, an open source 5G core network software. By leveraging Canonical Juju software automation and orchestration engine, Charmed Aether SD-Core can be easily deployed and managed, with observability in place.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,9 @@
 # Charmed Aether SD-Core
 
+> **:warning: Deprecation Notice!**
+>
+> This project is deprecated and will not receive further updates. Please refer to the upstream [Aether](https://aetherproject.org/) project to continue using Aether.
+
 Aether SD-Core is an open source 5G core network distributed by the Linux Foundation as part of its Aether directed fund project. SD-Core (Software-Defined Core) was previously distributed by the Open Networking Foundation (ONF).
 
 Aether SD-Core addresses the need for a cost-effective open source 5G core network, as opposed to traditionally costly mobile networking software. It supports various functionalities, including user authentication, IP address assignment, data traffic policy management, quality of service assurance, and network slice management.


### PR DESCRIPTION
# Description

Add deprecation notice to let users know that we are deprecating Charmed Aether SD-Core.

# Checklist:

- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
